### PR TITLE
Order book populate size with amount value on click

### DIFF
--- a/src/pages/Crypto/Order/LimitPrice.tsx
+++ b/src/pages/Crypto/Order/LimitPrice.tsx
@@ -43,6 +43,9 @@ export const LimitPrice: FC = () => {
     setOrder((prevState) => ({ ...prevState, type: checked ? 'postOnly' : 'limit' }))
 
   const localCSS = css`
+    .order-price {
+      padding: 0 2px;
+    }
     .order-price .ant-input-affix-wrapper {
       background-color: ${mode === 'dark' ? '#191919' : '#525252'};
     }

--- a/src/pages/Crypto/Order/Size.tsx
+++ b/src/pages/Crypto/Order/Size.tsx
@@ -20,6 +20,10 @@ export const Size: FC = () => {
   const userBalance = useMemo(() => (tokenInfo ? getUIAmount(tokenInfo.address) : 0), [tokenInfo, getUIAmount])
 
   const localCSS = css`
+    .order-size {
+      padding: 0 2px;
+    }
+
     .order-size .ant-input-affix-wrapper {
       background-color: ${mode === 'dark' ? '#191919' : '#525252'};
     }
@@ -39,9 +43,7 @@ export const Size: FC = () => {
         maxLength={15}
         onBlur={() => setFocused(undefined)}
         onChange={(x: BaseSyntheticEvent) => {
-          if (!isNaN(x.target.value)) {
-            setOrder((prevState) => ({ ...prevState, size: x.target.value }))
-          }
+          !isNaN(x.target.value) && setOrder((prevState) => ({ ...prevState, size: x.target.value }))
         }}
         onFocus={() => setFocused('size')}
         pattern="\d+(\.\d+)?"

--- a/src/pages/Crypto/Order/Total.tsx
+++ b/src/pages/Crypto/Order/Total.tsx
@@ -19,6 +19,9 @@ export const Total: FC = () => {
   const userBalance = useMemo(() => (tokenInfo ? getUIAmount(tokenInfo.address) : 0), [tokenInfo, getUIAmount])
 
   const localCSS = css`
+    .order-total {
+      padding: 0 2px;
+    }
     .order-total .ant-input-affix-wrapper {
       background-color: ${mode === 'dark' ? '#191919' : '#bdbdbd'};
     }

--- a/src/pages/Crypto/OrderBook.tsx
+++ b/src/pages/Crypto/OrderBook.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useMemo, useState } from 'react'
+import React, { FC, ReactNode, useMemo, useState, MouseEvent } from 'react'
 import { Skeleton } from 'antd'
 import styled from 'styled-components'
 import { Expand } from '../../components'
@@ -24,7 +24,6 @@ const HEADER = styled.div<{ $side: MarketSide }>`
 
     &:first-child {
       text-align: left;
-      cursor: pointer;
     }
 
     &:last-child {
@@ -73,10 +72,23 @@ const ORDER = styled.div`
     &:first-child {
       text-align: left;
       cursor: pointer;
+
+      &:hover {
+        font-weight: bold;
+      }
+    }
+
+    &:nth-child(2) {
+      cursor: pointer;
+
+      &:hover {
+        font-weight: bold;
+      }
     }
 
     &:nth-child(3) {
       text-align: right;
+      cursor: auto;
     }
   }
 `
@@ -145,11 +157,21 @@ export const OrderBook: FC = () => {
     [slicedOrderBook]
   )
 
-  const handleClick = () => setOrder((prevState) => ({ ...prevState, isHidden: !prevState.isHidden }))
+  const handleExpandToggle = () => setOrder((prevState) => ({ ...prevState, isHidden: !prevState.isHidden }))
+
+  const handleSetPrice = (price: number) => {
+    setOrder((prevState) => ({ ...prevState, price }))
+    setFocused('price')
+  }
+
+  const handleSetSize = (size: number) => {
+    setOrder((prevState) => ({ ...prevState, size }))
+    setFocused('size')
+  }
 
   return (
     <WRAPPER>
-      <Expand onClick={handleClick} />
+      <Expand onClick={handleExpandToggle} />
       <HEADER $side={side}>
         <SIDE $side={side}>
           <span onClick={() => setSide('bids')}>Live buy orders</span>
@@ -171,15 +193,12 @@ export const OrderBook: FC = () => {
               acc.totalValue += value
               acc.nodes.push(
                 <ORDER key={index}>
-                  <span
-                    onClick={() => {
-                      setOrder((prevState) => ({ ...prevState, price }))
-                      setFocused('price')
-                    }}
-                  >
+                  <span onClick={(e: MouseEvent<HTMLSpanElement>) => handleSetPrice(price)}>
                     ${removeFloatingPointError(price)}
                   </span>
-                  <span>{removeFloatingPointError(size)}</span>
+                  <span onClick={(e: MouseEvent<HTMLSpanElement>) => handleSetSize(size)}>
+                    {removeFloatingPointError(size)}
+                  </span>
                   <span>${abbreviateNumber(value, 2)}</span>
                   <SIZE style={{ width: `${(acc.totalValue / totalOrderBookValue) * 100}%` }} $side={side} />
                 </ORDER>


### PR DESCRIPTION
- Updates `OrderBook` with functionality to handle setting the "Size" input value when user clicks values in the "Amount" column of the order book
- adds hover styles to clickable order book values
- fixes hidden sides of focus indicator on input fields in the order form
