### PR TITLE
Prevents Order Form Collapse

### DIFF
--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -10,6 +10,7 @@ const BODY = styled(CenteredDiv)`
   flex-direction: column;
   height: 100%;
   padding: ${({ theme }) => theme.margins['3x']} 0;
+  min-height: 138px;
 
   > div:not(:last-child) {
     margin-bottom: ${({ theme }) => theme.margins['1.5x']};

--- a/src/pages/Crypto/Order/Order.tsx
+++ b/src/pages/Crypto/Order/Order.tsx
@@ -10,8 +10,6 @@ import { useOrder } from '../../../context'
 
 const CONTENT = styled.div<{ $display: boolean }>`
   position: relative;
-  opacity: ${({ $display }) => ($display ? '1' : '0')};
-  max-height: ${({ $display }) => ($display ? '1000px' : '0')};
   overflow: hidden;
   transition: all ${({ theme }) => theme.mainTransitionTime} ease-in-out;
 

--- a/src/pages/Crypto/OrderBook.tsx
+++ b/src/pages/Crypto/OrderBook.tsx
@@ -48,7 +48,10 @@ const ORDERS = styled.div<{ $visible: boolean }>`
   ${({ theme }) => theme.flexColumnNoWrap}
   justify-content: space-between;
   align-items: center;
-  max-height: ${({ $visible }) => ($visible ? '1000px' : '212px')};
+  max-height: ${({ $visible }) => ($visible ? '330px' : 'auto')};
+  padding-right: 2px;
+  overflow-y: scroll;
+  ${({ theme }) => theme.customScrollBar('4px')};
   transition: max-height ${({ theme }) => theme.mainTransitionTime} ease-in-out;
 `
 
@@ -123,11 +126,10 @@ const SIZE = styled.span<{ $side: MarketSide }>`
   height: 100%;
   background-color: ${({ theme, $side }) => theme[$side]}50;
 `
-
 const WRAPPER = styled.div`
   position: relative;
-  padding: ${({ theme }) => theme.margins['2x']} ${({ theme }) => theme.margins['2x']}
-    ${({ theme }) => theme.margins['1.5x']};
+  padding: ${({ theme }) => theme.margins['2x']} calc(${({ theme }) => theme.margins['2x']} - 2px)
+    ${({ theme }) => theme.margins['2x']} ${({ theme }) => theme.margins['1.5x']};
   border-radius: 10px;
   background-color: ${({ theme }) => theme.bg3};
   overflow: hidden;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -72,6 +72,7 @@ export function colors(mode: string): Colors {
     grey4: '#121212',
     grey5: '#1a1a1a',
     darkButton: '#000000',
+    scrollBarColor: mode === 'dark' ? '#434343' : '#e0e0e0',
 
     // specialty colors
     appLayoutFooterBorder: mode === 'dark' ? '#c4c4c4' : '#dedede',
@@ -196,6 +197,23 @@ export function theme(mode: string): DefaultTheme {
     measurements: (size) => css`
       height: ${size};
       width: ${size};
+    `,
+
+    customScrollBar: (size) => css`
+      scrollbar-width: thin;
+      scrollbar-color: ${({ theme }) => theme.scrollBarColor} transparent;
+
+      &::-webkit-scrollbar {
+        width: ${size};
+      }
+
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: ${({ theme }) => theme.scrollBarColor};
+        border-radius: 20px;
     `
   }
 }

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -31,6 +31,7 @@ export interface Colors {
   grey4: Color
   grey5: Color
   darkButton: Color
+  scrollBarColor: Color
 
   // speciality colors
   appLayoutFooterBorder: Color
@@ -120,5 +121,6 @@ declare module 'styled-components' {
 
     // mixins
     measurements: (number) => FlattenSimpleInterpolation
+    customScrollBar: (number) => FlattenInterpolation<ThemeProps<DefaultTheme>>
   }
 }


### PR DESCRIPTION
Prevents collapsing of order form when expanding the order book. 

The order book defaults to 10 rows and expands to 20 rows on toggle. This update manipulates the height of the parent div to expand in the available space below with the overflow scrolling on the y-axis.