### PR TITLE
Fixes Crypto Trading Slider Recalculation

### DIFF
--- a/src/pages/Crypto/Order/Total.tsx
+++ b/src/pages/Crypto/Order/Total.tsx
@@ -1,8 +1,9 @@
-import React, { BaseSyntheticEvent, FC, useMemo } from 'react'
+import React, { BaseSyntheticEvent, FC, useMemo, useCallback, useRef } from 'react'
 import { Input, Slider } from 'antd'
 import { css } from 'styled-components'
 import { FieldHeader, Picker } from './shared'
 import { useDarkMode, useCrypto, useOrder, useTokenRegistry, useAccounts } from '../../../context'
+import { removeFloatingPointError, debounce } from '../../../utils'
 
 export const Total: FC = () => {
   const { getUIAmount } = useAccounts()
@@ -32,6 +33,13 @@ export const Total: FC = () => {
     }
   `
 
+  const handleSliderChange = (total: number) =>
+    setOrder((prevState) => ({
+      ...prevState,
+      size: removeFloatingPointError(total / (order.price || 1)),
+      total
+    }))
+
   return (
     <div className="order-total">
       <style>{localCSS}</style>
@@ -56,7 +64,7 @@ export const Total: FC = () => {
           <Slider
             max={userBalance}
             min={0}
-            onChange={(total) => setOrder((prevState) => ({ ...prevState, total }))}
+            onChange={handleSliderChange}
             step={selectedCrypto.market?.tickSize}
             value={order.total}
           />

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -85,3 +85,12 @@ export function useLocalStorageState(key: string, defaultState?: string) {
 
   return [state, setLocalStorageState]
 }
+
+export function debounce(callback: any, wait: number) {
+  let timeout
+  return (...args) => {
+    const context = this
+    clearTimeout(timeout)
+    timeout = setTimeout(() => callback.apply(context, args), wait)
+  }
+}


### PR DESCRIPTION
1. Fixes the order form slider control's recalculation for order total. 

2. The frequency of the state update driven by the slider's activity could impact the efficiency of functions/components hooked to updates on the state object. Currently there are no functions/components being affected but a debounce function has been defined in utils to handle this in the future should it be necessary.