### PR TITLE
add tooltip text farm page table headers

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -19,8 +19,9 @@ export const Tooltip: FC<{
   dark?: boolean
   lite?: boolean
   placement?: TooltipPlacement
+  color?: string
   children: ReactNode
-}> = ({ dark, lite, placement = 'topLeft', children }) => {
+}> = ({ dark, lite, placement = 'topLeft', color = '#4b4b4b', children }) => {
   const { mode } = useDarkMode()
 
   const icon = `${process.env.PUBLIC_URL}/img/assets/tooltip_${dark ? 'dark' : lite ? 'lite' : mode}_mode_icon.svg`
@@ -28,7 +29,7 @@ export const Tooltip: FC<{
   return (
     <ANTDTooltip
       arrowPointAtCenter
-      color="#4b4b4b"
+      color={color}
       overlayInnerStyle={{ borderRadius: '8px', display: 'flex', alignItems: 'center', padding: '8px' }}
       placement={placement}
       title={<TEXT>{children}</TEXT>}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -30,7 +30,13 @@ export const Tooltip: FC<{
     <ANTDTooltip
       arrowPointAtCenter
       color={color}
-      overlayInnerStyle={{ borderRadius: '8px', display: 'flex', alignItems: 'center', padding: '8px' }}
+      overlayInnerStyle={{
+        borderRadius: '8px',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '8px 8px 0',
+        maxWidth: '132px'
+      }}
       placement={placement}
       title={<TEXT>{children}</TEXT>}
     >

--- a/src/pages/Farm/Columns.tsx
+++ b/src/pages/Farm/Columns.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Tooltip } from '../../components/Tooltip'
 
 const STYLED_TITLE = styled.div`
   display: flex;
@@ -62,17 +63,27 @@ const STYLED_EARNED = styled.div`
   text-align: center;
 `
 
-const Title = (text, isInfo, isArrowDown) => (
+const HeaderTooltip = (text: string) => {
+  return (
+    <img className="info-icon" src={`${process.env.PUBLIC_URL}/img/assets/info-icon.svg`} alt="" /> && (
+      <Tooltip dark placement="bottomLeft" color="#000000">
+        <p>{text}</p>
+      </Tooltip>
+    )
+  )
+}
+
+const Title = (text: string, infoText: string, isArrowDown: boolean) => (
   <STYLED_TITLE>
     <div className="text">{text}</div>
-    {isInfo && <img className="info-icon" src={`${process.env.PUBLIC_URL}/img/assets/info-icon.svg`} alt="" />}
+    {infoText && HeaderTooltip(infoText)}
     {isArrowDown && <img className="arrow-down" src={`${process.env.PUBLIC_URL}/img/assets/arrow-down.svg`} alt="" />}
   </STYLED_TITLE>
 )
 
 export const columns = [
   {
-    title: Title('Name', false, true),
+    title: Title('Name', '', true),
     dataIndex: 'name',
     key: 'name',
     width: '15%',
@@ -89,33 +100,33 @@ export const columns = [
     )
   },
   {
-    title: Title('Earned', 1, 1),
+    title: Title('Earned', '', true),
     dataIndex: 'earned',
     key: 'earned',
     width: '10%',
     render: (text) => <STYLED_EARNED>{text}</STYLED_EARNED>
   },
   {
-    title: Title('APR', 1, 1),
+    title: Title('APR', 'Yearly deposit earned on your deposit.', true),
     dataIndex: 'apr',
     key: 'apr',
     width: '12%',
     render: (text) => <div className="apr normal-text">{text}</div>
   },
   {
-    title: Title('Rewards', 1, 1),
+    title: Title('Rewards', '', true),
     dataIndex: 'rewards',
     key: 'rewards',
     render: (text) => <div className="rewards normal-text">{text}</div>
   },
   {
-    title: Title('Liquidity', 1, 1),
+    title: Title('Liquidity', "Total value of funds in this farm's liquidity pool.", true),
     dataIndex: 'liquidity',
     key: 'liquidity',
     render: (text) => <div className="liquidity normal-text">{text}</div>
   },
   {
-    title: Title('Volume (24h)', false, true),
+    title: Title('Volume (24h)', '', true),
     dataIndex: 'volume',
     key: 'volume',
     width: '12%',


### PR DESCRIPTION
- Adds support for tooltip text on /farm page table
- Addresses https://github.com/GooseFX1/gfx-web-app/issues/100

<img width="1426" alt="Screen Shot 2022-01-25 at 6 17 30 PM" src="https://user-images.githubusercontent.com/6132555/151076263-a3d7a3f5-5eb9-4baf-9dfe-8d86620bb03a.png">

