### PR TITLE
update pagination colors for light theme

### DIFF
--- a/src/pages/Farm/TableList.tsx
+++ b/src/pages/Farm/TableList.tsx
@@ -84,23 +84,24 @@ const STYLED_TABLE_LIST = styled(Table)`
   .ant-pagination-item {
     a {
       display: inline;
+      color: ${theme.text6};
     }
 
     &:hover{
       a {
-        color: ${theme.white};
+        color: ${theme.text6};
       }
     }
 
     &:hover{
-      border-color: ${theme.white};
+      border-color: ${theme.text6};
     }
   }
 
   .ant-pagination-item-active {
     border-color: transparent;
     a {
-      color: ${theme.text8};
+      color: ${theme.text6};
     }
 
     &:hover {
@@ -109,9 +110,11 @@ const STYLED_TABLE_LIST = styled(Table)`
   }
 
   .ant-pagination-item-link {
+    color: ${theme.text6};
+
     &:hover {
-      border-color: ${theme.white};
-      color: ${theme.white};
+      border-color: ${theme.text6};
+      color: ${theme.text6};
     }
   }
 


### PR DESCRIPTION
- Fixes the colors on the pagination selectors at the bottom of the page
- https://github.com/GooseFX1/gfx-web-app/issues/101

<img width="1418" alt="Screen Shot 2022-01-28 at 2 48 53 PM" src="https://user-images.githubusercontent.com/6132555/151613851-0ea8de31-1d3a-4610-8296-3c5d821967ee.png">

<img width="1438" alt="Screen Shot 2022-01-28 at 3 17 35 PM" src="https://user-images.githubusercontent.com/6132555/151615505-4974264b-395d-4aad-aa68-bbb41e8a2a0c.png">

