### PR TITLE
NFT Exchange: Discrepancy Bidding Small Amounts

### DIFF
--- a/src/pages/NFTs/OpenBidNFT/BidModal.tsx
+++ b/src/pages/NFTs/OpenBidNFT/BidModal.tsx
@@ -78,7 +78,7 @@ const PURCHASE_MODAL = styled(Modal)`
 
   .ant-modal-body {
     padding: ${({ theme }) => theme.margin(4.5)};
-    padding-bottom: ${({ theme }) => theme.margin(1)};
+    padding-bottom: ${({ theme }) => theme.margin(5)};
     overflow: auto !important;
   }
 
@@ -165,18 +165,16 @@ const PURCHASE_MODAL = styled(Modal)`
     }
   }
 
-  .bm-not-enough-funds {
-    visibility: hidden;
+  .bm-not-enough {
     margin-top: ${({ theme }) => theme.margin(1)};
+    padding-bottom: ${({ theme }) => theme.margin(1)};
     text-align: center;
     font-size: 13px;
     font-weight: 600;
     color: #ff6b6b;
-  }
-
-  .bm-not-enough-visible {
-    visibility: visible;
-    padding-bottom: ${({ theme }) => theme.margin(1)};
+    position: absolute;
+    width: 100%;
+    left: 0;
   }
 
   .bm-review-alert {
@@ -645,9 +643,11 @@ export const BidModal: FC<IBidModal> = ({ setVisible, visible, purchasePrice }: 
           status="initial"
           width="100%"
           height="53px"
-          className={`bm-bid-button ${notEnough || bidPriceInput.length === 0 ? 'bm-bid-button-disabled' : ''}`}
+          className={`bm-bid-button ${
+            notEnough || bidPriceInput.length === 0 || bidPrice < 0.021 ? 'bm-bid-button-disabled' : ''
+          }`}
           onClick={reviewBid}
-          disabled={notEnough || bidPriceInput.length === 0}
+          disabled={notEnough || bidPriceInput.length === 0 || bidPrice < 0.021}
         >
           Review bid
         </BUTTON>
@@ -658,15 +658,18 @@ export const BidModal: FC<IBidModal> = ({ setVisible, visible, purchasePrice }: 
           status="initial"
           width="100%"
           height="53px"
-          className={`bm-confirm-button ${notEnough || bidPriceInput.length === 0 ? 'bm-bid-button-disabled' : ''}`}
+          className={`bm-confirm-button ${
+            notEnough || bidPriceInput.length === 0 || bidPrice < 0.021 ? 'bm-bid-button-disabled' : ''
+          }`}
           onClick={callBuyInstruction}
           loading={isLoading}
-          disabled={isLoading || notEnough || bidPriceInput.length === 0}
+          disabled={isLoading || notEnough || bidPriceInput.length === 0 || bidPrice < 0.021}
         >
           Send bid
         </BUTTON>
       )}
-      <div className={`bm-not-enough-funds ${notEnough ? 'bm-not-enough-visible' : ''}`}>Not enough funds </div>
+      {notEnough && <div className={`bm-not-enough`}>Not enough funds </div>}
+      {bidPriceInput.length > 0 && bidPrice < 0.021 && <div className={`bm-not-enough`}>Bid too small </div>}
     </PURCHASE_MODAL>
   )
 }

--- a/src/pages/NFTs/Slider/NFTHomeSlider.tsx
+++ b/src/pages/NFTs/Slider/NFTHomeSlider.tsx
@@ -5,6 +5,7 @@ import 'slick-carousel/slick/slick-theme.css'
 import styled from 'styled-components'
 import { MainButton } from '../../../components/MainButton'
 
+//#region styles
 const CAROUSEL_WRAPPER = styled.div`
   position: relative;
   padding-left: ${({ theme }) => theme.margin(4)};
@@ -13,7 +14,7 @@ const CAROUSEL_WRAPPER = styled.div`
     position: absolute;
     top: 0;
     right: 0;
-    height: 100%;
+    height: 99%;
     width: 180px;
     background: ${({ theme }) => theme.fade};
   }
@@ -44,17 +45,15 @@ const CAROUSEL_WRAPPER = styled.div`
 const SLIDER_ITEM = styled.div`
   margin-right: ${({ theme }) => theme.margin(4)};
   position: relative;
-  width: 40%;
 
   .home-slider-image {
     border-radius: 10px;
-    height: auto;
-    width: 41vw;
-    margin: 0 auto;
+    height: 34vh;
+    width: auto;
   }
 
   .home-slider-content {
-    width: 58%;
+    width: 100%;
     text-align: center;
     position: absolute;
     top: 50%;
@@ -92,6 +91,7 @@ const ORANGE_BTN = styled(MainButton)`
 const TERTIERY_BTN = styled(MainButton)`
   background: ${({ theme }) => theme.primary3} !important;
 `
+//#endregion
 
 const settings = {
   infinite: false,
@@ -107,14 +107,6 @@ const settings = {
 }
 
 export const NFTHomeSlider = () => {
-  const [isSlideData, setIsSlideData] = useState(false)
-
-  useEffect(() => {
-    setTimeout(() => {
-      setIsSlideData(true)
-    }, 1000)
-  }, [])
-
   const handleCreatorApply = (e: any) => {
     window.open('https://docs.google.com/forms/d/15yypvXd49oTMv0AbtfZ8CU_y2Z7WGJI0KmilA8oR6OA/edit')
   }

--- a/src/pages/NFTs/actions.ts
+++ b/src/pages/NFTs/actions.ts
@@ -13,6 +13,8 @@ import {
   CancelInstructionAccounts,
   SellInstructionAccounts,
   BuyInstructionAccounts,
+  WithdrawInstructionArgs,
+  WithdrawInstructionAccounts,
   StringPublicKey,
   bnTo8
 } from '../../web3'
@@ -143,4 +145,23 @@ export const callCancelInstruction = async (
   const confirm = await connection.confirmTransaction(signature, 'processed')
   console.log(confirm)
   return { signature, confirm }
+}
+
+export const callWithdrawInstruction = async (wallet: PublicKey, escrow: [PublicKey, number], bidAmount: BN) => {
+  const withdrawInstructionArgs: WithdrawInstructionArgs = {
+    escrowPaymentBump: escrow[1],
+    amount: bidAmount
+  }
+
+  const withdrawInstructionAccounts: WithdrawInstructionAccounts = {
+    wallet: wallet,
+    receiptAccount: wallet,
+    escrowPaymentAccount: escrow[0],
+    treasuryMint: new PublicKey(TREASURY_MINT),
+    authority: new PublicKey(AUCTION_HOUSE_AUTHORITY),
+    auctionHouse: new PublicKey(AUCTION_HOUSE),
+    auctionHouseFeeAccount: new PublicKey(AH_FEE_ACCT)
+  }
+
+  return { withdrawInstructionAccounts, withdrawInstructionArgs }
 }


### PR DESCRIPTION
There is a discrepancy on the wallet amount (tx on block explorer) from the amount bid in the UI.
Testing needs to be done around the value that is being sent to the RPC calls

Problem
In the metaplex auction house contract, bids smaller than the escrow payment account will not invoke a transfer of funds from the users wallet to the escrow account. Escrow is initialized to 0.02 so the minimum a user can bid is 0.021 to invoke a transfer.

Reference: https://github.com/metaplex-foundation/metaplex-program-library/blob/master/auction-house/program/src/bid/mod.rs#L198

Additionally, funds are not being returned to the users wallet when cancelling a bid because the withdraw instruction is not being called.

**Solution**
This update validates user bid input to meet minimum and invoke withdraw instruction on cancel bid.