### PR TITLE
NFT Exchange: Fix RangeError in 1of1 Mint

### DIFF
--- a/src/pages/NFTs/Collectible/UploadCustom.tsx
+++ b/src/pages/NFTs/Collectible/UploadCustom.tsx
@@ -113,6 +113,10 @@ const STYLED_UPLOAD_CUSTOM = styled.div`
   `}
 `
 const STYLED_UPLOAD_ERROR = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
   .image-broken {
     width: 83px;
     height: 83px;

--- a/src/web3/transactions.ts
+++ b/src/web3/transactions.ts
@@ -302,7 +302,7 @@ export async function awaitTransactionSignatureConfirmation(
   })
 
   //@ts-ignore
-  if (connection._signatureSubscriptions[subId]) connection.removeSignatureListener(subId)
+  if (connection?._signatureSubscriptions?.[subId]) connection?.removeSignatureListener(subId)
   done = true
   console.log('Returning status', status)
   return status

--- a/src/web3/transactions.ts
+++ b/src/web3/transactions.ts
@@ -275,7 +275,7 @@ export async function awaitTransactionSignatureConfirmation(
         try {
           const signatureStatuses = await connection.getSignatureStatuses([txid])
           status = signatureStatuses && signatureStatuses.value[0]
-          console.log(explorerLinkFor(txid, connection))
+
           if (!done) {
             if (!status) {
               console.log('REST null result for', txid, status)


### PR DESCRIPTION
<!-- TITLE FORMATTING -->
<!-- ClickUp, “UI: Farm - Create Header” becomes “Farm: Create Header” in pull requests -->

## Description
This change fixes a bug in the `Create 1 of 1 NFT` where the integer was not the correct data type.

## How has this been tested?
This was tested locally by two devs with the result being two 1of1 NFTs being minted.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [x] My code follows the code style of this project .
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots or Loom Video (if appropriate):
