### PR TITLE
NFT Exchange: Share Profile

### DIFF
--- a/src/api/NFTs/constants.ts
+++ b/src/api/NFTs/constants.ts
@@ -2,6 +2,7 @@ export const NFT_API_BASE = 'nest-api'
 
 export enum NFT_API_ENDPOINTS {
   SESSION_USER = '/user',
+  NON_SESSION_USER = '/user',
   USER_ACTIVITY = '/user-activity',
   ALL_COLLECTIONS = '/all-collections',
   ALL_LIKES = '/all-likes',

--- a/src/context/settings.tsx
+++ b/src/context/settings.tsx
@@ -21,7 +21,7 @@ export const ENDPOINTS: IEndpoint[] = [
   {
     chainId: ENV.Devnet,
     name: 'QuickNode',
-    endpoint: 'https://muddy-rough-leaf.solana-devnet.quiknode.pro/542f5d1429c8b5bfaaf947ca4be72847c2e24859/',
+    endpoint: 'https://muddy-rough-leaf.solana-devnet.quiknode.pro/91e35cc4d4906726624ed977e65ab9a3a73d4083/',
     network: WalletAdapterNetwork.Devnet
   },
   {

--- a/src/layouts/App/Connect.tsx
+++ b/src/layouts/App/Connect.tsx
@@ -16,6 +16,7 @@ import { useWalletModal } from '../../context'
 import { CenteredImg } from '../../styles'
 import { Loader } from '../../components'
 import { WalletName } from '@solana/wallet-adapter-wallets'
+import { truncateAddress } from '../../utils'
 
 const WALLET_ICON = styled(CenteredImg)`
   ${({ theme }) => theme.measurements(theme.margin(3))}
@@ -134,7 +135,7 @@ export const Connect: FC = () => {
         </WRAPPED_LOADER>
       )
     } else {
-      return base58.substr(0, 4) + '..' + base58.substr(-4, 4)
+      return truncateAddress(base58)
     }
   }, [wallet, base58])
 

--- a/src/pages/NFTs/Collectible/RoyaltiesStep.tsx
+++ b/src/pages/NFTs/Collectible/RoyaltiesStep.tsx
@@ -5,6 +5,7 @@ import { Row, Col, Slider, InputNumber, Typography, Button } from 'antd'
 import InfoInput from './InfoInput'
 import { PopupCustom } from '../Popup/PopupCustom'
 import { Creator, StringPublicKey } from '../../../web3'
+import { truncateAddress } from '../../../utils'
 const { Text } = Typography
 
 //#region styles
@@ -430,7 +431,7 @@ const RoyaltiesSplitter = ({ creators, royalties, setRoyalties, isShowErrors, re
                 <img className="close-white-icon" src={`/img/assets/close-white-icon.svg`} alt="" />
               </div>
 
-              <div className={'label'}>{`${creator.label.substr(0, 4)}...${creator.label.substr(-4, 4)}`}</div>
+              <div className={'label'}>{truncateAddress(creator.label)}</div>
 
               <div className={'slider'}>
                 <Slider value={amt} onChange={handleChangeShare} />

--- a/src/pages/NFTs/Collectible/SellNFT.tsx
+++ b/src/pages/NFTs/Collectible/SellNFT.tsx
@@ -408,7 +408,7 @@ export const SellNFT = () => {
           } else {
             setTimeout(() => {
               notify(successfulListingMsg(signature, nftMetadata, userInput['minimumBid']))
-              history.push('/NFTs/profile')
+              history.push(`/NFTs/profile/${publicKey.toBase58()}`)
             }, 2000)
           }
         })

--- a/src/pages/NFTs/Collectible/SellNFT.tsx
+++ b/src/pages/NFTs/Collectible/SellNFT.tsx
@@ -10,7 +10,7 @@ import { SellCategory } from '../SellCategory/SellCategory'
 import { FormDoubleItem } from '../Form/FormDoubleItem'
 import { SuccessfulListingMsg, TransactionErrorMsg, MainButton, Modal } from '../../../components'
 import { NFT_MARKET_TRANSACTION_FEE } from '../../../constants'
-import { notify } from '../../../utils'
+import { notify, truncateAddress } from '../../../utils'
 import { registerSingleNFT } from '../../../api/NFTs'
 import {
   tradeStatePDA,
@@ -223,7 +223,7 @@ export const SellNFT = () => {
     if (nftMetadata === undefined) return null
     if (nftMetadata.properties.creators.length > 0) {
       const addr = nftMetadata.properties.creators[0].address
-      return `${addr.substr(0, 4)}...${addr.substr(-4, 4)}`
+      return truncateAddress(addr)
     } else if (nftMetadata.collection) {
       return Array.isArray(nftMetadata.collection) ? nftMetadata.collection[0].name : nftMetadata.collection.name
     } else {

--- a/src/pages/NFTs/Collectible/UpLoadNFT.tsx
+++ b/src/pages/NFTs/Collectible/UpLoadNFT.tsx
@@ -344,7 +344,7 @@ export const UpLoadNFT = (): JSX.Element => {
 
     setTimeout(() => {
       history.push({
-        pathname: '/NFTs/profile',
+        pathname: `/NFTs/profile/${wallet.publicKey.toBase58()}`,
         state: { newlyMintedNFT: { name: name, metadataAccount: metadataAccount } }
       })
     }, 1500)

--- a/src/pages/NFTs/Collection/Card.tsx
+++ b/src/pages/NFTs/Collection/Card.tsx
@@ -147,7 +147,7 @@ export const Card = (props: ICard) => {
   const history = useHistory()
   const { mode } = useDarkMode()
   const { connection } = useConnectionConfig()
-  const { sessionUser, parsedAccounts, likeDislike } = useNFTProfile()
+  const { sessionUser, sessionUserParsedAccounts, likeDislike } = useNFTProfile()
   const [localSingleNFT, setlocalSingleNFT] = useState(undefined)
   /** setters are only for populating context before location change to details page */
   const { setGeneral, setNftMetadata, setBids, setAsk, setTotalLikes } = useNFTDetails()
@@ -170,11 +170,11 @@ export const Card = (props: ICard) => {
   const isOwner: boolean = useMemo(() => {
     if (props.userId) return true
     const findAccount: undefined | ParsedAccount =
-      props.singleNFT && parsedAccounts !== undefined
-        ? parsedAccounts.find((acct) => acct.mint === props.singleNFT.mint_address)
+      props.singleNFT && sessionUserParsedAccounts !== undefined
+        ? sessionUserParsedAccounts.find((acct) => acct.mint === props.singleNFT.mint_address)
         : undefined
     return findAccount === undefined ? false : true
-  }, [parsedAccounts])
+  }, [sessionUserParsedAccounts])
 
   useEffect(() => {
     if (props.singleNFT) {

--- a/src/pages/NFTs/Collection/CollectionHeader.tsx
+++ b/src/pages/NFTs/Collection/CollectionHeader.tsx
@@ -245,14 +245,12 @@ export const CollectionHeader = ({ setFilter, filter, collapse, setCollapse }) =
   const isCollectionItemEmpty: boolean = !singleCollection || !fixedPriceWithinCollection || !openBidWithinCollection
   // const isCollectionItemEmpty: boolean = true
 
-  const handleClick = (e) => setShareModal(true)
-
   const handleSweepClick = () => {
     setSweeperModal(true)
   }
 
   const menu = (
-    <MENU_LIST onClick={handleClick}>
+    <MENU_LIST onClick={(e) => setShareModal(true)}>
       <Menu.Item key="share">Share</Menu.Item>
       {/* <Menu.Item>Report</Menu.Item> */}
     </MENU_LIST>

--- a/src/pages/NFTs/Home/Header.tsx
+++ b/src/pages/NFTs/Home/Header.tsx
@@ -285,12 +285,11 @@ export const Header = ({ setFilter, filter, filteredCollections, totalCollection
           </div>
         ) : (
           <div style={{ display: 'flex' }}>
-            {isCollapsed &&
-              !connected(
-                <CONNECT onClick={handleWalletModal}>
-                  <span>Connect Wallet</span>
-                </CONNECT>
-              )}
+            {isCollapsed && !connected && (
+              <CONNECT onClick={handleWalletModal}>
+                <span>Connect Wallet</span>
+              </CONNECT>
+            )}
             <SELL onClick={goProfile}>
               <span>Sell</span>
             </SELL>

--- a/src/pages/NFTs/Home/Header.tsx
+++ b/src/pages/NFTs/Home/Header.tsx
@@ -14,6 +14,7 @@ import PopupCompleteProfile from '../Profile/PopupCompleteProfile'
 import { useNFTProfile } from '../../../context'
 import { SkeletonCommon } from '../Skeleton/SkeletonCommon'
 
+//#region styles
 const HEADER_WRAPPER = styled(SpaceBetweenDiv)`
   padding-top: ${({ theme }) => theme.margin(5.5)};
   padding-bottom: ${({ theme }) => theme.margin(3)};
@@ -139,6 +140,7 @@ const AVATAR_NFT = styled(Image)`
   cursor: pointer;
   margin-right: ${({ theme }) => theme.margin(1.5)};
 `
+//#endregion
 
 export const Header = ({ setFilter, filter, filteredCollections, totalCollections, setTotalCollections }) => {
   const history = useHistory()
@@ -151,9 +153,7 @@ export const Header = ({ setFilter, filter, filteredCollections, totalCollection
   const [isHeaderData, setIsHeaderData] = useState<boolean>(false)
 
   useEffect(() => {
-    setTimeout(() => {
-      setIsHeaderData(true)
-    }, 1000)
+    setTimeout(() => setIsHeaderData(true), 1000)
   }, [])
 
   useEffect(() => {
@@ -185,14 +185,14 @@ export const Header = ({ setFilter, filter, filteredCollections, totalCollection
   const onSkip = useCallback(() => handleDismissModal(), [handleDismissModal])
   const onContinue = useCallback(() => {
     handleDismissModal()
-    history.push({ pathname: '/NFTs/profile', state: { isCreatingProfile: true } })
+    history.push({ pathname: `/NFTs/profile/${publicKey.toBase58()}`, state: { isCreatingProfile: true } })
   }, [handleDismissModal])
 
   const onCreateCollectible = () => {
     history.push('/NFTs/create')
   }
 
-  const goProfile = () => history.push(`/NFTs/profile`)
+  const goProfile = () => history.push(`/NFTs/profile/${publicKey.toBase58()}`)
 
   const handleWalletModal: MouseEventHandler<HTMLButtonElement> = useCallback(
     (event) => {
@@ -285,11 +285,12 @@ export const Header = ({ setFilter, filter, filteredCollections, totalCollection
           </div>
         ) : (
           <div style={{ display: 'flex' }}>
-            {isCollapsed && (
-              <CONNECT onClick={handleWalletModal}>
-                <span>Connect Wallet</span>
-              </CONNECT>
-            )}
+            {isCollapsed &&
+              !connected(
+                <CONNECT onClick={handleWalletModal}>
+                  <span>Connect Wallet</span>
+                </CONNECT>
+              )}
             <SELL onClick={goProfile}>
               <span>Sell</span>
             </SELL>

--- a/src/pages/NFTs/NFTDetails/BidModal.tsx
+++ b/src/pages/NFTs/NFTDetails/BidModal.tsx
@@ -421,7 +421,7 @@ export const BidModal: FC<IBidModal> = ({ setVisible, visible, purchasePrice }: 
           } else if (res.data.bid_matched && res.data.tx_sig) {
             fetchUser()
             notify(successBidMatchedMessage(res.data.tx_sig, nftMetadata, bidPrice.toString()))
-            setTimeout(() => history.push('/NFTs/profile'), 2000)
+            setTimeout(() => history.push(`/NFTs/profile/${publicKey.toBase58()}`), 2000)
           } else {
             setVisible(false)
           }

--- a/src/pages/NFTs/NFTDetails/BidModal.tsx
+++ b/src/pages/NFTs/NFTDetails/BidModal.tsx
@@ -5,7 +5,7 @@ import { useWallet } from '@solana/wallet-adapter-react'
 import styled from 'styled-components'
 import { Col, Row } from 'antd'
 import { MainButton, Modal, SuccessfulListingMsg } from '../../../components'
-import { notify } from '../../../utils'
+import { notify, truncateAddress } from '../../../utils'
 import { useNFTProfile, usePriceFeed, useNFTDetails, useConnectionConfig, useAccounts } from '../../../context'
 import { NFT_MARKET_TRANSACTION_FEE } from '../../../constants'
 import BN from 'bn.js'
@@ -251,7 +251,7 @@ export const BidModal: FC<IBidModal> = ({ setVisible, visible, purchasePrice }: 
     if (nftMetadata === undefined) return null
     if (nftMetadata.properties.creators.length > 0) {
       const addr = nftMetadata.properties.creators[0].address
-      return `${addr.substr(0, 4)}...${addr.substr(-4, 4)}`
+      return truncateAddress(addr)
     } else if (nftMetadata.collection) {
       return Array.isArray(nftMetadata.collection) ? nftMetadata.collection[0].name : nftMetadata.collection.name
     } else {

--- a/src/pages/NFTs/NFTDetails/RightSection.tsx
+++ b/src/pages/NFTs/NFTDetails/RightSection.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useMemo, FC } from 'react'
-import { useWallet } from '@solana/wallet-adapter-react'
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { Col, Row } from 'antd'
 import styled, { css } from 'styled-components'
-import { moneyFormatter } from '../../../utils'
+import { moneyFormatter, truncateAddress } from '../../../utils'
 import { RightSectionTabs } from './RightSectionTabs'
 import { useNFTDetails, usePriceFeed } from '../../../context'
 import { MintItemViewStatus } from '../../../types/nft_details'
@@ -153,7 +152,6 @@ const HIGHEST_BIDDER = styled.span`
 export const RightSection: FC<{
   status: MintItemViewStatus
 }> = ({ status, ...rest }) => {
-  const { publicKey } = useWallet()
   const { general, nftMetadata, bids, curHighestBid, ask } = useNFTDetails()
   const { prices } = usePriceFeed()
 
@@ -162,7 +160,7 @@ export const RightSection: FC<{
       return Array.isArray(nftMetadata.collection) ? nftMetadata.collection[0].name : nftMetadata.collection?.name
     } else if (nftMetadata?.properties?.creators?.length > 0) {
       const addr = nftMetadata?.properties?.creators?.[0]?.address
-      return `${addr.substr(0, 4)}...${addr.substr(-4, 4)}`
+      return truncateAddress(addr)
     } else {
       return null
     }

--- a/src/pages/NFTs/NFTDetails/RightSectionTabs.tsx
+++ b/src/pages/NFTs/NFTDetails/RightSectionTabs.tsx
@@ -12,7 +12,7 @@ import { AttributesTabContent } from './AttributesTabContent'
 import RemoveModalContent from './RemoveModalContent'
 import { Modal, SuccessfulListingMsg } from '../../../components'
 import { NFT_MARKET_TRANSACTION_FEE } from '../../../constants'
-import { notify } from '../../../utils'
+import { notify, truncateAddress } from '../../../utils'
 import { tradeStatePDA, callCancelInstruction, callWithdrawInstruction, tokenSize } from '../actions'
 import { removeNonCollectionListing } from '../../../api/NFTs'
 import { BidModal } from './BidModal'
@@ -274,17 +274,15 @@ export const RightSectionTabs: FC<{
       : [
           {
             title: 'Mint address',
-            value: `${general.mint_address.substr(0, 4)}...${general.mint_address.substr(-4, 4)}`
+            value: truncateAddress(general.mint_address)
           },
           {
             title: 'Token Address',
-            value: general.token_account
-              ? `${general.token_account.substr(0, 4)}...${general.token_account.substr(-4, 4)}`
-              : ''
+            value: general.token_account ? truncateAddress(general.token_account) : ''
           },
           {
             title: 'Owner',
-            value: general.owner ? `${general.owner.substr(0, 6)}...${general.owner.substr(-4, 4)}` : ''
+            value: general.owner ? truncateAddress(general.owner) : ''
           },
           {
             title: 'Artist Royalties',

--- a/src/pages/NFTs/NFTDetails/RightSectionTabs.tsx
+++ b/src/pages/NFTs/NFTDetails/RightSectionTabs.tsx
@@ -595,7 +595,10 @@ export const RightSectionTabs: FC<{
               </SpaceBetweenDiv>
             )
           ) : (
-            <button className="rst-footer-button rst-footer-button-bid" onClick={(e) => history.push('/NFTs/profile')}>
+            <button
+              className="rst-footer-button rst-footer-button-bid"
+              onClick={(e) => history.push(`/NFTs/profile/${wallet.publicKey.toBase58()}`)}
+            >
               Complete profile
             </button>
           )}

--- a/src/pages/NFTs/NFTDetails/TradingHistoryTabContent.tsx
+++ b/src/pages/NFTs/NFTDetails/TradingHistoryTabContent.tsx
@@ -3,6 +3,7 @@ import { Table, Row, Col } from 'antd'
 import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import styled, { css } from 'styled-components'
 import { useNFTDetails } from '../../../context'
+import { truncateAddress } from '../../../utils'
 
 const TRADING_HISTORY_TAB_CONTENT = styled.div`
   ${({ theme }) => css`
@@ -102,18 +103,14 @@ const bidColumns = [
     key: 'wallet_key',
     dataIndex: 'wallet_key',
     title: 'From',
-    render: (value: string) => (
-      <div className="thtc-from-to">{`${value.slice(0, 4)}...${value.slice(value.length - 4, value.length - 1)}`}</div>
-    ),
+    render: (value: string) => <div className="thtc-from-to">{truncateAddress(value)}</div>,
     width: '19%'
   },
   {
     key: 'token_account_mint_key',
     dataIndex: 'token_account_mint_key',
     title: 'To',
-    render: (value: string) => (
-      <div className="thtc-from-to">{`${value.slice(0, 4)}...${value.slice(value.length - 4, value.length - 1)}`}</div>
-    ),
+    render: (value: string) => <div className="thtc-from-to">{truncateAddress(value)}</div>,
     width: '19%'
   },
   {

--- a/src/pages/NFTs/NFTs.tsx
+++ b/src/pages/NFTs/NFTs.tsx
@@ -93,7 +93,7 @@ export const NFTs: FC = () => {
                 <Route exact path={path}>
                   <NFTLandingPage />
                 </Route>
-                <Route exact path={['/NFTs/profile', '/NFTs/profile/:userId']}>
+                <Route exact path={['/NFTs/profile', '/NFTs/profile/:userAddress']}>
                   <Profile />
                 </Route>
                 <Route exact path="/NFTs/collection/:collectionId">

--- a/src/pages/NFTs/Profile/ContentProfile.tsx
+++ b/src/pages/NFTs/Profile/ContentProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, FC } from 'react'
 import { useWallet } from '@solana/wallet-adapter-react'
 import { useNFTProfile, useConnectionConfig } from '../../../context'
 import { ISingleNFT } from '../../../types/nft_details.d'
@@ -9,22 +9,54 @@ import NFTDisplay from './NFTDisplay'
 import Activity from './Activity'
 
 type Props = {
-  isExplore?: boolean
+  isSessionUser: boolean
 }
 
-export const ContentProfile = ({ isExplore }: Props) => {
+export const ContentProfile: FC<Props> = ({ isSessionUser }: Props): JSX.Element => {
+  const { connection } = useConnectionConfig()
   const { publicKey } = useWallet()
-  const { sessionUser, parsedAccounts, userActivity, setUserActivity, fetchUserActivity } = useNFTProfile()
+  const {
+    sessionUser,
+    sessionUserParsedAccounts,
+    nonSessionProfile,
+    nonSessionUserParsedAccounts,
+    userActivity,
+    setUserActivity,
+    fetchUserActivity
+  } = useNFTProfile()
   const [createdItems, setCreatedItems] = useState<ParsedAccount[]>()
   const [favoritedItems, setFavoritedItems] = useState<ISingleNFT[]>()
-  const { connection } = useConnectionConfig()
+
+  const currentUserProfile = useMemo(() => {
+    console.log(sessionUser, nonSessionProfile)
+
+    if (nonSessionProfile !== undefined && !isSessionUser) {
+      return nonSessionProfile
+    } else if (sessionUser !== undefined && isSessionUser) {
+      return sessionUser
+    } else {
+      return undefined
+    }
+  }, [isSessionUser, sessionUser, nonSessionProfile])
+
+  const currentUserParsedAccounts = useMemo(() => {
+    console.log(sessionUserParsedAccounts, nonSessionUserParsedAccounts)
+
+    if (nonSessionUserParsedAccounts !== undefined && !isSessionUser) {
+      return nonSessionUserParsedAccounts
+    } else if (sessionUserParsedAccounts !== undefined && isSessionUser) {
+      return sessionUserParsedAccounts
+    } else {
+      return undefined
+    }
+  }, [isSessionUser, sessionUserParsedAccounts, nonSessionUserParsedAccounts])
 
   const tabPanes = useMemo(
     () => [
       {
         order: '1',
-        name: `My Collection (${parsedAccounts ? parsedAccounts.length : 0})`,
-        component: <NFTDisplay parsedAccounts={parsedAccounts} type={'collected'} />
+        name: `My Collection (${currentUserParsedAccounts ? currentUserParsedAccounts.length : 0})`,
+        component: <NFTDisplay parsedAccounts={currentUserParsedAccounts} type={'collected'} />
       },
       {
         order: '2',
@@ -33,16 +65,16 @@ export const ContentProfile = ({ isExplore }: Props) => {
       },
       {
         order: '3',
-        name: `Favorited (${favoritedItems ? favoritedItems.length : 0})`,
-        component: <NFTDisplay singleNFT={favoritedItems} type={'favorited'} />
+        name: `Favorited (${isSessionUser && favoritedItems ? favoritedItems.length : 0})`,
+        component: <NFTDisplay singleNFT={isSessionUser ? favoritedItems : []} type={'favorited'} />
       },
       {
         order: '4',
         name: 'Activity',
-        component: <Activity data={userActivity ? userActivity : []} />
+        component: <Activity data={isSessionUser && userActivity ? userActivity : []} />
       }
     ],
-    [parsedAccounts, createdItems, userActivity, favoritedItems]
+    [currentUserParsedAccounts, createdItems, userActivity, favoritedItems]
   )
 
   useEffect(() => {
@@ -50,16 +82,16 @@ export const ContentProfile = ({ isExplore }: Props) => {
   }, [tabPanes])
 
   useEffect(() => {
-    if (sessionUser && parsedAccounts && parsedAccounts.length > 0) {
-      const userCreated = parsedAccounts.filter(
+    if (currentUserProfile && currentUserParsedAccounts && currentUserParsedAccounts.length > 0) {
+      const userCreated = currentUserParsedAccounts.filter(
         (nft: ParsedAccount) =>
-          nft.data.creators !== undefined && nft.data.creators.find((c) => c.address === publicKey.toBase58())
+          nft.data.creators !== undefined && nft.data.creators.find((c) => c.address === currentUserProfile.pubkey)
       )
       setCreatedItems(userCreated)
     } else {
       setCreatedItems([])
     }
-  }, [parsedAccounts])
+  }, [currentUserParsedAccounts])
 
   useEffect(() => {
     if (sessionUser?.user_likes?.length > 0) {

--- a/src/pages/NFTs/Profile/NFTDisplay.tsx
+++ b/src/pages/NFTs/Profile/NFTDisplay.tsx
@@ -16,12 +16,12 @@ import debounce from 'lodash.debounce'
 interface INFTDisplay {
   type: 'collected' | 'created' | 'favorited'
   parsedAccounts?: ParsedAccount[]
-  singleNFT?: ISingleNFT[]
+  singleNFTs?: ISingleNFT[]
 }
 
 const NFTDisplay = (props: INFTDisplay): JSX.Element => {
   const location = useLocation<ILocationState>()
-  const { sessionUser } = useNFTProfile()
+  const { sessionUser, nonSessionProfile } = useNFTProfile()
   const [collectedItems, setCollectedItems] = useState<ISingleNFT[]>()
   const [filteredCollectedItems, setFilteredCollectedItems] = useState<ISingleNFT[]>()
   const [search, setSearch] = useState<string>('')
@@ -65,8 +65,8 @@ const NFTDisplay = (props: INFTDisplay): JSX.Element => {
   // }, [location])
 
   useEffect(() => {
-    if (props.singleNFT) {
-      setCollectedItemsPag(props.singleNFT)
+    if (props.singleNFTs) {
+      setCollectedItemsPag(props.singleNFTs)
     } else if (!props.parsedAccounts || props.parsedAccounts.length === 0) {
       setCollectedItemsPag([])
     } else {
@@ -76,7 +76,7 @@ const NFTDisplay = (props: INFTDisplay): JSX.Element => {
     }
 
     return () => setCollectedItemsPag(undefined)
-  }, [props.singleNFT, props.parsedAccounts])
+  }, [props.singleNFTs, props.parsedAccounts])
 
   useEffect(() => {
     if (collectedItems) {
@@ -108,7 +108,7 @@ const NFTDisplay = (props: INFTDisplay): JSX.Element => {
           animation_url: '',
           collection_id: null,
           token_account: null,
-          owner: sessionUser.pubkey
+          owner: nonSessionProfile === undefined ? sessionUser.pubkey : nonSessionProfile.pubkey
         })
       } catch (error) {
         console.error(error)

--- a/src/pages/NFTs/Profile/Profile.tsx
+++ b/src/pages/NFTs/Profile/Profile.tsx
@@ -5,17 +5,9 @@ import { useWallet } from '@solana/wallet-adapter-react'
 import styled from 'styled-components'
 import { HeaderProfile } from './HeaderProfile'
 import { ContentProfile } from './ContentProfile'
-import { Loader } from '../../../components'
-import { useNFTProfile, unnamedUser } from '../../../context'
+import { useNFTProfile } from '../../../context'
 
 //#region styles
-const WRAPPED_LOADER = styled.div`
-  position: relative;
-  height: 48px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`
 const PROFILE_CONTAINER = styled.div`
   display: flex;
   flex-direction: column;
@@ -75,7 +67,7 @@ const PROFILE_CONTAINER = styled.div`
 export const Profile: FC = (): JSX.Element => {
   const history = useHistory()
   const params = useParams<IAppParams>()
-  const { sessionUser, setSessionUser, setParsedAccounts, setNonSessionProfile, setNonSessionUserParsedAccounts } =
+  const { sessionUser, setUserActivity, setParsedAccounts, setNonSessionProfile, setNonSessionUserParsedAccounts } =
     useNFTProfile()
   const { connected, publicKey } = useWallet()
   const [isSessionUser, setIsSessionUser] = useState<boolean>()
@@ -86,7 +78,6 @@ export const Profile: FC = (): JSX.Element => {
     // asserts there is no wallet connection and no session user
     if (sessionUser === undefined || !connected || publicKey === null) {
       setIsSessionUser(false)
-      setSessionUser(unnamedUser)
       setParsedAccounts([])
     }
 
@@ -98,6 +89,7 @@ export const Profile: FC = (): JSX.Element => {
     return () => {
       setNonSessionProfile(undefined)
       setNonSessionUserParsedAccounts([])
+      setUserActivity([])
     }
   }, [sessionUser, publicKey, connected, params.userAddress])
 

--- a/src/pages/NFTs/Profile/Profile.tsx
+++ b/src/pages/NFTs/Profile/Profile.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, FC } from 'react'
-// import { useParams } from 'react-router-dom'
-// import { IAppParams } from '../../../types/app_params.d'
+import { useParams, useHistory } from 'react-router-dom'
+import { IAppParams } from '../../../types/app_params.d'
 import { useWallet } from '@solana/wallet-adapter-react'
 import styled from 'styled-components'
 import { HeaderProfile } from './HeaderProfile'
@@ -8,6 +8,7 @@ import { ContentProfile } from './ContentProfile'
 import { Loader } from '../../../components'
 import { useNFTProfile, unnamedUser } from '../../../context'
 
+//#region styles
 const WRAPPED_LOADER = styled.div`
   position: relative;
   height: 48px;
@@ -69,39 +70,43 @@ const PROFILE_CONTAINER = styled.div`
     }
   }
 `
+//#endregion
 
 export const Profile: FC = (): JSX.Element => {
-  // const params = useParams<IAppParams>()
-  const [loading, setLoading] = useState(true)
-  const { sessionUser, setSessionUser, setParsedAccounts } = useNFTProfile()
+  const history = useHistory()
+  const params = useParams<IAppParams>()
+  const { sessionUser, setSessionUser, setParsedAccounts, setNonSessionProfile, setNonSessionUserParsedAccounts } =
+    useNFTProfile()
   const { connected, publicKey } = useWallet()
+  const [isSessionUser, setIsSessionUser] = useState<boolean>()
 
   useEffect(() => {
-    if (sessionUser && connected && publicKey) {
-      setLoading(false)
-    } else {
-      setUnnamedUser()
+    if (params.userAddress === undefined) history.push(`/NFTs`)
+
+    // asserts there is no wallet connection and no session user
+    if (sessionUser === undefined || !connected || publicKey === null) {
+      setIsSessionUser(false)
+      setSessionUser(unnamedUser)
+      setParsedAccounts([])
     }
 
-    return () => {}
-  }, [sessionUser, publicKey, connected])
+    if (publicKey !== null) {
+      console.log('!!!PROFILE LOAD!!!', params.userAddress, publicKey.toBase58())
+      setIsSessionUser(params.userAddress === publicKey.toBase58())
+    }
 
-  const setUnnamedUser = () => {
-    setSessionUser(unnamedUser)
-    setParsedAccounts([])
-    setLoading(false)
-  }
+    return () => {
+      setNonSessionProfile(undefined)
+      setNonSessionUserParsedAccounts([])
+    }
+  }, [sessionUser, publicKey, connected, params.userAddress])
 
-  return loading ? (
-    <WRAPPED_LOADER>
-      <Loader />
-    </WRAPPED_LOADER>
-  ) : !sessionUser ? (
-    <h2>Something went wrong fetching user profile</h2>
-  ) : (
-    <PROFILE_CONTAINER>
-      <HeaderProfile />
-      <ContentProfile />
-    </PROFILE_CONTAINER>
+  return (
+    isSessionUser !== undefined && (
+      <PROFILE_CONTAINER>
+        <HeaderProfile isSessionUser={isSessionUser} />
+        <ContentProfile isSessionUser={isSessionUser} />
+      </PROFILE_CONTAINER>
+    )
   )
 }

--- a/src/types/app_params.d.ts
+++ b/src/types/app_params.d.ts
@@ -1,7 +1,7 @@
 export interface IAppParams {
   collectionId: string
   nftId: string
-  userId: string
+  userAddress: string
   nftMintAddress: string
 }
 

--- a/src/types/nft_profile.d.ts
+++ b/src/types/nft_profile.d.ts
@@ -31,10 +31,15 @@ export interface INFTProfileConfig {
   sessionUser: INFTProfile
   setSessionUser: Dispatch<SetStateAction<INFTProfile>>
   fetchSessionUser: (type: UserFetchType, parameter: string | number, connection: Connection) => Promise<any>
-  parsedAccounts: ParsedAccount[]
+  sessionUserParsedAccounts: ParsedAccount[]
   setParsedAccounts: Dispatch<SetStateAction<ParsedAccount[]>>
   userActivity: Array<INFTUserActivity>
   setUserActivity: Dispatch<SetStateAction<INFTUserActivity[]>>
   fetchUserActivity: (id: number) => Promise<any>
   likeDislike: Function
+  nonSessionProfile: INFTProfile
+  fetchNonSessionProfile: (type: UserFetchType, parameter: string | number, connection: Connection) => Promise<any>
+  nonSessionUserParsedAccounts: ParsedAccount[]
+  setNonSessionProfile: Dispatch<SetStateAction<INFTProfile>>
+  setNonSessionUserParsedAccounts: Dispatch<SetStateAction<ParsedAccount[]>>
 }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -155,3 +155,5 @@ export const getLast = <T>(arr: T[]) => {
 
   return arr[arr.length - 1]
 }
+
+export const truncateAddress = (address: string): string => `${address.substr(0, 4)}..${address.substr(-4, 4)}`


### PR DESCRIPTION
## Description
This update allows viewing of any wallet collection. There is a new route and route param that allows rendering of collectables via `NFTs/profile/<address>`.

Additionally, there is a "Share Profile" button in the profile header.

## How has this been tested?
Testing was done locally where the following paths were performed:
- navigating to route where no address was specified
- navigating to route where address was specified but there was no wallet connection
- navigating to route where address was specified and there was a wallet connection
- navigating to route where address was specified, there was a wallet connection, and that wallet was disconnected or changed
- sharing of URLs of all social media sites

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [x] My code follows the code style of this project .
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
