### PR TITLE
fix: allow new traders to deposit in devnet

### DIFF
--- a/src/pages/TradeV3/perps/DepositWithdraw.tsx
+++ b/src/pages/TradeV3/perps/DepositWithdraw.tsx
@@ -208,7 +208,7 @@ export const DepositWithdraw: FC<{
   }
   const checkDisabled = () => {
     if (isDevnet) {
-      if (!traderInfo.traderRiskGroup) return true
+      if (!traderInfo.traderRiskGroup) return false
       if (traderInfo.traderRiskGroup.totalDeposited.toJSON().m !== '0') return true
       return false
     }


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
At the moment in the perps interface, the deposit button in the deposit modal is disabled when a new trader toggles to devnet. This fix enables the button by setting the disabled state to false if the trader risk group doesn't exist.
## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
