### PR TITLE
fix: prevent layout from reseting when a user refreshes the trade page

### DIFF
--- a/src/pages/TradeV3/TradeContainer.tsx
+++ b/src/pages/TradeV3/TradeContainer.tsx
@@ -299,6 +299,7 @@ export const CryptoContent: FC = () => {
   const { selectedCrypto, isDevnet } = useCrypto()
   const { wallet } = useWallet()
   const [chartContainer, setChartContainer] = useState<any>()
+  const isInitialRender = useRef(true)
 
   useEffect(() => {
     logData('trade_page')
@@ -313,7 +314,11 @@ export const CryptoContent: FC = () => {
   }, [isDevnet, selectedCrypto, mode])
 
   useEffect(() => {
-    resetLayout()
+    if (!isInitialRender.current) {
+      resetLayout()
+    } else if (width !== undefined) {
+      isInitialRender.current = false
+    }
   }, [width])
 
   const getRowHeight = (height: number) => (height < 800 ? 20 : height / 38)


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
At the moment when a user refreshes the trade page their layout configuration is reset, this is because the layout had been set to refresh when the window width changes but this does not account for whether it's the first render of the component and whether the width is changing from an actual value that was set before or from undefined to e.g 1440.
## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
