### PR TITLE
fix: default order size to zero if it's undefined and default it to max qty if it exceeds it when calculating slider value

### DIFF
--- a/src/pages/TradeV3/PlaceOrder.tsx
+++ b/src/pages/TradeV3/PlaceOrder.tsx
@@ -823,7 +823,11 @@ export const PlaceOrder: FC = () => {
     const initLeverage = Number(traderInfo.currentLeverage)
     const availLeverage = Number(traderInfo.availableLeverage)
     const qty = maxQtyNum
-    const orderSize = order.size || 0
+    let orderSize = order.size || 0
+    // we do this so that the displayed leverage doesn't exceed 10x
+    if (Number(orderSize) > qty) {
+      orderSize = qty
+    }
     //const availMargin = Number(traderInfo.marginAvailable)
     let percentage = 0
     percentage = (Number(orderSize) / qty) * availLeverage

--- a/src/pages/TradeV3/PlaceOrder.tsx
+++ b/src/pages/TradeV3/PlaceOrder.tsx
@@ -823,9 +823,11 @@ export const PlaceOrder: FC = () => {
     const initLeverage = Number(traderInfo.currentLeverage)
     const availLeverage = Number(traderInfo.availableLeverage)
     const qty = maxQtyNum
+    const orderSize = order.size || 0
     //const availMargin = Number(traderInfo.marginAvailable)
     let percentage = 0
-    percentage = (Number(order.size) / qty) * availLeverage
+    percentage = (Number(orderSize) / qty) * availLeverage
+
     //else if (order.total < availMargin) percentage = (Number(order.total) / Number(availMargin)) * availLeverage
     return Number((initLeverage + percentage).toFixed(2))
     //return Number(initLeverage.toFixed(2))


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
This fixes the bug where NAN is being displayed as leverage before a user inputs their size. It also fixes the bug where leverage value is set to a number greater than 10 if a user inputs an order size greater than their maximum allowed quantity.
## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
