### PR TITLE
fix: hide scrollbar in the recent trades component

### DIFF
--- a/src/pages/TradeV3/RecentTrades.tsx
+++ b/src/pages/TradeV3/RecentTrades.tsx
@@ -28,6 +28,14 @@ const WRAPPER = styled.div`
   width: 100%;
   padding: 0px 0px 0px 0px;
   overflow: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  /* Hide scrollbar for IE, Edge and Firefox */
+  & {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
 `
 const TRADES = styled.div`
   ${tw`h-[31px] w-full p-0 text-xs h-7`}


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
Hide scrollbar in the
![image](https://github.com/GooseFX1/gfx-web-app/assets/29974159/96215054-582e-4b2d-bb77-6d21d9b52ef6)
 recent trades section
## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
