### PR TITLE
Rewards Timer Adjust + RPC Removal

### DIFF
--- a/src/components/rewards/v2/rightPanel/RewardsClaimButton.tsx
+++ b/src/components/rewards/v2/rightPanel/RewardsClaimButton.tsx
@@ -14,8 +14,8 @@ function RewardsClaimButton(): JSX.Element {
   const [isClaiming, setIsClaiming] = useBoolean(false)
   const { isDone, time } = useTimer({
     targetTime: {
-      hour: 9,
-      minute: 30,
+      hour: 10,
+      minute: 0,
       second: 0
     },
     format: '[Claim In:] hh[H] mm[Min]'

--- a/src/context/accounts.tsx
+++ b/src/context/accounts.tsx
@@ -175,7 +175,7 @@ export const AccountsProvider: FC<{ children: ReactNode }> = ({ children }) => {
         }
         setDevnetBalances(accounts)
       } catch (e: any) {
-        await notify({ type: 'error', message: `Error fetching accounts`, icon: 'error' }, e)
+        // await notify({ type: 'error', message: `Error fetching accounts`, icon: 'error' }, e)
       }
 
       setFetching(false)

--- a/src/pages/FarmV3/ActionModal.tsx
+++ b/src/pages/FarmV3/ActionModal.tsx
@@ -137,7 +137,7 @@ export const ActionModal: FC<{
         >
           {`${
             actionType === 'deposit'
-              ? `Deposit ${commafy(depositAmount, 4)} ${token?.token} + Claim rewards`
+              ? `Deposit ${commafy(+depositAmount, 4)} ${token?.token} + Claim rewards`
               : actionType === 'withdraw'
               ? `Withdraw ${commafy(+withdrawAmount + claimAmount, 4)} ${token?.token}`
               : `${claimAmount ? `${commafy(claimAmount, 4)} ${token?.token}` : '00.00 ' + token?.token}`


### PR DESCRIPTION
Rewards Timer Adjust + RPC Removal
## Description
Moved rewards timer to 10AM UTC, removed notification from RPC failure
## How has this been tested?
Local testing
## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
