### PR TITLE
fix: format dates en-US, keep history tab open on account page sidebar, copy updates

### DIFF
--- a/src/pages/Account/components/AccountOverview.tsx
+++ b/src/pages/Account/components/AccountOverview.tsx
@@ -141,7 +141,7 @@ const HISTORY = styled.div`
   }
 `
 
-const columns = ['Asset', 'Balance', 'USD Value', 'Liq.Price']
+const columns = ['Asset', 'Balance', 'USD Value', 'Liq Price']
 const AccountOverview: FC = () => {
   const { mode } = useDarkMode()
   const [dayVolume, setDayVolume] = useState<number>(0)
@@ -282,14 +282,12 @@ const AccountOverview: FC = () => {
             </div>
             <span>{roundedSize} SOL</span>
             <span>${formatNumberInThousands(Number(notionalSize))}</span>
-            <span>
-              {Number(traderInfo.liquidationPrice) == 0 ? 'None' : Number(traderInfo.liquidationPrice).toFixed(2)}
-            </span>
+            <span>${Number(traderInfo.liquidationPrice).toFixed(2)}</span>
           </div>
         ) : (
           <div className="no-balances-found">
             <img src={`/img/assets/NoPositionsFound_${mode}.svg`} alt="no-balances-found" />
-            <p>No Balances Found</p>
+            <p>No Active Positions</p>
             {!connected && <Connect />}
             {connected && (
               <button onClick={() => setDepositWithdrawModal(true)} className="deposit">

--- a/src/pages/Account/components/DepositWithdaw.tsx
+++ b/src/pages/Account/components/DepositWithdaw.tsx
@@ -10,6 +10,7 @@ import { DepositWithdraw } from '../../TradeV3/perps/DepositWithdraw'
 import { GET_USER_FUND_TRANSFERS } from '../../TradeV3/perps/perpsConstants'
 import { httpClient } from '../../../api'
 import { Pagination } from './Pagination'
+import { convertUnixTimestampToFormattedDate } from '../../TradeV3/perps/utils'
 
 const WRAPPER = styled.div`
   ${tw`flex flex-col w-full`}
@@ -136,15 +137,6 @@ const DepositWithdrawHistory: FC = () => {
     fetchFundTransfers()
   }, [connected, publicKey, pagination])
 
-  function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
-    // Create a new Date object using the Unix timestamp (in milliseconds)
-    const date = new Date(unixTimestamp)
-
-    // Format the date as "MM/DD/YYYY hh:mmAM/PM"
-    const formattedDate = `${date.toLocaleDateString('en-GB')} ${date.toLocaleTimeString('en-US')}`
-
-    return formattedDate
-  }
   return (
     <WRAPPER>
       {depositWithdrawModal && (
@@ -197,7 +189,7 @@ const DepositWithdrawHistory: FC = () => {
         ) : (
           <div className="no-deposits-found">
             <img src={`/img/assets/NoPositionsFound_${mode}.svg`} alt="no-deposits-found" />
-            <p>No deposits Found</p>
+            <p>No Deposits Found</p>
             {!connected && <Connect />}
             {connected && (
               <button onClick={() => setDepositWithdrawModal(true)} className="deposit">

--- a/src/pages/Account/components/FundingHistory.tsx
+++ b/src/pages/Account/components/FundingHistory.tsx
@@ -13,6 +13,7 @@ import { httpClient } from '../../../api'
 import { GET_USER_FUNDING_HISTORY } from '../../TradeV3/perps/perpsConstants'
 import { useTraderConfig } from '../../../context/trader_risk_group'
 import { Pagination } from './Pagination'
+import { convertUnixTimestampToFormattedDate } from '../../TradeV3/perps/utils'
 
 const WRAPPER = styled.div`
   ${tw`flex flex-col w-full`}
@@ -166,15 +167,7 @@ const FundingHistory: FC = () => {
     [getAskSymbolFromPair, selectedCrypto.pair]
   )
   const assetIcon = useMemo(() => `/img/crypto/${symbol}.svg`, [symbol, selectedCrypto.type])
-  function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
-    // Create a new Date object using the Unix timestamp (in milliseconds)
-    const date = new Date(unixTimestamp * 1000)
 
-    // Format the date as "MM/DD/YYYY hh:mmAM/PM"
-    const formattedDate = `${date.toLocaleDateString('en-GB')} ${date.toLocaleTimeString('en-US')}`
-
-    return formattedDate
-  }
   const fetchFundingHistory = async () => {
     const res = await httpClient('api-services').get(`${GET_USER_FUNDING_HISTORY}`, {
       params: {
@@ -255,7 +248,7 @@ const FundingHistory: FC = () => {
                   <span>
                     {(item.fundingBalanceDifference / 10 ** (Number(item.fundingBalance.exp) + 5)).toFixed(4)}
                   </span>
-                  <span>{convertUnixTimestampToFormattedDate(item.time)}</span>
+                  <span>{convertUnixTimestampToFormattedDate(item.time * 1000)}</span>
                 </div>
               ))}
             </div>

--- a/src/pages/Account/components/Mobile/AccountOverview.tsx
+++ b/src/pages/Account/components/Mobile/AccountOverview.tsx
@@ -270,19 +270,15 @@ const MobileAccountOverview: FC = () => {
                 <span className="ml-auto">${formatNumberInThousands(Number(notionalSize))}</span>
               </div>
               <div className="flex w-full">
-                <span>Liq. Price</span>
-                <span className="ml-auto">
-                  {Number(traderInfo.liquidationPrice) == 0
-                    ? 'None'
-                    : Number(traderInfo.liquidationPrice).toFixed(2)}
-                </span>
+                <span>Liq Price</span>
+                <span className="ml-auto">${Number(traderInfo.liquidationPrice).toFixed(2)}</span>
               </div>
             </div>
           </div>
         ) : (
           <div className="no-balances-found">
             <img src={`/img/assets/NoPositionsFound_${mode}.svg`} alt="no-balances-found" />
-            <p>No Balances Found</p>
+            <p>No Active Positions</p>
             {!connected && <Connect />}
             {connected && (
               <button onClick={() => setDepositWithdrawModal(true)} className="deposit">

--- a/src/pages/Account/components/Mobile/DepositWithdaw.tsx
+++ b/src/pages/Account/components/Mobile/DepositWithdaw.tsx
@@ -10,6 +10,7 @@ import { DepositWithdraw } from '../../../TradeV3/perps/DepositWithdraw'
 import { GET_USER_FUND_TRANSFERS } from '../../../TradeV3/perps/perpsConstants'
 import { httpClient } from '../../../../api'
 import { Pagination } from '../Pagination'
+import { convertUnixTimestampToFormattedDate } from '../../../TradeV3/perps/utils'
 
 const WRAPPER = styled.div`
   ${tw`flex flex-col w-full`}
@@ -123,15 +124,6 @@ const MobileDepositWithdrawHistory: FC = () => {
     fetchFundTransfers()
   }, [connected, publicKey, pagination])
 
-  function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
-    // Create a new Date object using the Unix timestamp (in milliseconds)
-    const date = new Date(unixTimestamp)
-
-    // Format the date as "MM/DD/YYYY hh:mmAM/PM"
-    const formattedDate = `${date.toLocaleDateString('en-GB')} ${date.toLocaleTimeString('en-US')}`
-
-    return formattedDate
-  }
   return (
     <WRAPPER>
       {depositWithdrawModal && (
@@ -191,7 +183,7 @@ const MobileDepositWithdrawHistory: FC = () => {
         ) : (
           <div className="no-deposits-found">
             <img src={`/img/assets/NoPositionsFound_${mode}.svg`} alt="no-deposits-found" />
-            <p>No deposits Found</p>
+            <p>No Deposits Found</p>
             {!connected && <Connect />}
             {connected && (
               <button onClick={() => setDepositWithdrawModal(true)} className="deposit">

--- a/src/pages/Account/components/Mobile/FundingHistory.tsx
+++ b/src/pages/Account/components/Mobile/FundingHistory.tsx
@@ -13,6 +13,7 @@ import { httpClient } from '../../../../api'
 import { GET_USER_FUNDING_HISTORY } from '../../../TradeV3/perps/perpsConstants'
 import { useTraderConfig } from '../../../../context/trader_risk_group'
 import { Pagination } from '../Pagination'
+import { convertUnixTimestampToFormattedDate } from '../../../TradeV3/perps/utils'
 
 const WRAPPER = styled.div`
   ${tw`flex flex-col w-full`}
@@ -152,15 +153,7 @@ const MobileFundingHistory: FC = () => {
     [getAskSymbolFromPair, selectedCrypto.pair]
   )
   const assetIcon = useMemo(() => `/img/crypto/${symbol}.svg`, [symbol, selectedCrypto.type])
-  function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
-    // Create a new Date object using the Unix timestamp (in milliseconds)
-    const date = new Date(unixTimestamp * 1000)
 
-    // Format the date as "MM/DD/YYYY hh:mmAM/PM"
-    const formattedDate = `${date.toLocaleDateString('en-GB')} ${date.toLocaleTimeString('en-US')}`
-
-    return formattedDate
-  }
   const fetchFundingHistory = async () => {
     const res = await httpClient('api-services').get(`${GET_USER_FUNDING_HISTORY}`, {
       params: {
@@ -250,7 +243,7 @@ const MobileFundingHistory: FC = () => {
                   </div>
                   <div className="flex">
                     <span>Date</span>
-                    <span className="ml-auto">{convertUnixTimestampToFormattedDate(item.time)}</span>
+                    <span className="ml-auto">{convertUnixTimestampToFormattedDate(item.time * 1000)}</span>
                   </div>
                 </div>
               ))}

--- a/src/pages/Account/components/Mobile/Trades.tsx
+++ b/src/pages/Account/components/Mobile/Trades.tsx
@@ -13,6 +13,7 @@ import { httpClient } from '../../../../api'
 import { GET_USER_TRADES_HISTORY } from '../../../TradeV3/perps/perpsConstants'
 import { useTraderConfig } from '../../../../context/trader_risk_group'
 import { Pagination } from '../Pagination'
+import { convertUnixTimestampToFormattedDate } from '../../../TradeV3/perps/utils'
 
 const WRAPPER = styled.div`
   ${tw`flex flex-col w-full`}
@@ -141,15 +142,6 @@ const MobileTrades: FC = () => {
     }
   }, [connected, publicKey, traderInfo.traderRiskGroupKey, pagination])
 
-  function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
-    // Create a new Date object using the Unix timestamp (in milliseconds)
-    const date = new Date(unixTimestamp * 1000)
-
-    // Format the date as "MM/DD/YYYY hh:mmAM/PM"
-    const formattedDate = `${date.toLocaleDateString('en-GB')} ${date.toLocaleTimeString('en-US')}`
-
-    return formattedDate
-  }
   return (
     <WRAPPER>
       {depositWithdrawModal && (
@@ -210,7 +202,7 @@ const MobileTrades: FC = () => {
                   </div>
                   <div className="flex">
                     <span>Date</span>
-                    <span className="ml-auto">{convertUnixTimestampToFormattedDate(trade.time)}</span>
+                    <span className="ml-auto">{convertUnixTimestampToFormattedDate(trade.time * 1000)}</span>
                   </div>
                 </div>
               ))}

--- a/src/pages/Account/components/Pagination.tsx
+++ b/src/pages/Account/components/Pagination.tsx
@@ -38,20 +38,16 @@ export const Pagination: FC<{
       setPagination({ page: pagination.page + 1, limit: pagination.limit })
     }
   }
+  function roundUpIfDecimal(number: number) {
+    if (number % 1 !== 0) {
+      return Math.ceil(number)
+    } else {
+      return number
+    }
+  }
   return (
     <WRAPPER>
-      <p>
-        {pagination.page == 1
-          ? 1
-          : pagination.page * pagination.limit >= totalItemsCount
-          ? totalItemsCount - pagination.limit * (pagination.page - 1)
-          : pagination.limit}{' '}
-        of{' '}
-        {pagination.page * pagination.limit >= totalItemsCount
-          ? totalItemsCount
-          : pagination.page * pagination.limit}{' '}
-        transactions
-      </p>
+      <p>{`Page ${pagination.page} of ${roundUpIfDecimal(totalItemsCount / pagination.limit)}`} </p>
       <div className="imagesContainer">
         <img
           src={

--- a/src/pages/Account/components/Sidebar.tsx
+++ b/src/pages/Account/components/Sidebar.tsx
@@ -78,6 +78,7 @@ const Sidebar: FC<SidebarProps> = ({ selected, setSelected }) => {
           alt="account history icon"
         />
         History
+        {/*
         <img
           src={
             mode === 'lite'
@@ -86,9 +87,9 @@ const Sidebar: FC<SidebarProps> = ({ selected, setSelected }) => {
           }
           alt="dropdown icon"
           style={historySelected ? { transform: 'rotate(180deg)' } : {}}
-        />
+        />*/}
       </SPAN>
-      <div className={historySelected ? 'show-history' : undefined}>
+      <div className={'show-history'}>
         <SPAN className={selected == 2 ? 'selected' : undefined} onClick={() => handleClick(2)}>
           Deposits
         </SPAN>

--- a/src/pages/Account/components/Trades.tsx
+++ b/src/pages/Account/components/Trades.tsx
@@ -13,6 +13,7 @@ import { httpClient } from '../../../api'
 import { GET_USER_TRADES_HISTORY } from '../../TradeV3/perps/perpsConstants'
 import { useTraderConfig } from '../../../context/trader_risk_group'
 import { Pagination } from './Pagination'
+import { convertUnixTimestampToFormattedDate } from '../../TradeV3/perps/utils'
 
 const WRAPPER = styled.div`
   ${tw`flex flex-col w-full`}
@@ -161,15 +162,6 @@ const Trades: FC = () => {
     }
   }, [connected, publicKey, pagination, traderInfo.traderRiskGroupKey])
 
-  function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
-    // Create a new Date object using the Unix timestamp (in milliseconds)
-    const date = new Date(unixTimestamp * 1000)
-
-    // Format the date as "MM/DD/YYYY hh:mmAM/PM"
-    const formattedDate = `${date.toLocaleDateString('en-GB')} ${date.toLocaleTimeString('en-US')}`
-
-    return formattedDate
-  }
   return (
     <WRAPPER>
       {depositWithdrawModal && (
@@ -212,7 +204,7 @@ const Trades: FC = () => {
                   <span>${trade.price.toFixed(2)}</span>
                   <span>${((trade.qty * trade.price * 0.1) / 100).toFixed(3)}</span>
                   <span className="filled">Filled</span>
-                  <span>{convertUnixTimestampToFormattedDate(trade.time)}</span>
+                  <span>{convertUnixTimestampToFormattedDate(trade.time * 1000)}</span>
                 </div>
               ))}
             </div>

--- a/src/pages/TradeV3/perps/utils.tsx
+++ b/src/pages/TradeV3/perps/utils.tsx
@@ -590,3 +590,13 @@ export const formatNumberInThousands = (number: number, minimumFractionDigits = 
     minimumFractionDigits,
     maximumFractionDigits
   })
+
+export function convertUnixTimestampToFormattedDate(unixTimestamp: number) {
+  // Create a new Date object using the Unix timestamp (in milliseconds)
+  const date = new Date(unixTimestamp)
+
+  // Format the date as "MM/DD/YYYY hh:mmAM/PM"
+  const formattedDate = `${date.toLocaleDateString('en-US')} ${date.toLocaleTimeString('en-US')}`
+
+  return formattedDate
+}


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
The copy updates include:
- Changed text at bottom on account overview page to "No Active Positions" instead of "No Balances Found" 
- Changed pagination text to Page 1, Page 2 e.t.c instead of x of y transactions

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
