### PR TITLE
Farm: Decimal Display

### DIFF
--- a/src/pages/FarmV3/ActionModal.tsx
+++ b/src/pages/FarmV3/ActionModal.tsx
@@ -3,7 +3,7 @@ import tw, { styled } from 'twin.macro'
 import 'styled-components/macro'
 import { Button, PopupCustom } from '../../components'
 import { SSLToken } from './constants'
-import { checkMobile, commafy, truncateBigNumber } from '../../utils'
+import { checkMobile, truncateBigNumber } from '../../utils'
 import { Drawer } from 'antd'
 import useBreakPoint from '../../hooks/useBreakPoint'
 import { useDarkMode } from '../../context'
@@ -188,10 +188,10 @@ export const ActionModal: FC<{
         >
           {`${
             actionType === 'deposit'
-              ? `Deposit ${commafy(+depositAmount, 2)} ${token?.token} + Claim Yield`
+              ? `Deposit ${truncateBigNumber(+depositAmount)} ${token?.token} + Claim Yield`
               : actionType === 'withdraw'
-              ? `Withdraw ${commafy(+withdrawAmount + claimAmount - earlyWithdrawFee, 2)} ${token?.token}`
-              : `${claimAmount ? `${commafy(claimAmount, 2)} ${token?.token}` : '00.00 ' + token?.token}`
+              ? `Withdraw ${truncateBigNumber(+withdrawAmount + claimAmount - earlyWithdrawFee)} ${token?.token}`
+              : `${claimAmount ? `${truncateBigNumber(claimAmount)} ${token?.token}` : '00.00 ' + token?.token}`
           }`}
         </Button>
         <div

--- a/src/pages/FarmV3/ExpandedView.tsx
+++ b/src/pages/FarmV3/ExpandedView.tsx
@@ -555,7 +555,7 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
               <div
                 onClick={() =>
                   modeOfOperation === ModeOfOperation.DEPOSIT
-                    ? setDepositAmount(userTokenBalance ? '00.01' : '0')
+                    ? setDepositAmount(userTokenBalance ? '00.01' : '0.0')
                     : setWithdrawAmount(userDepositedAmount ? '00.01' : '0')
                 }
                 tw="font-bold text-regular text-grey-1 dark:text-grey-2 ml-3 cursor-pointer"

--- a/src/pages/FarmV3/ExpandedView.tsx
+++ b/src/pages/FarmV3/ExpandedView.tsx
@@ -13,13 +13,12 @@ import {
   invalidDepositErrMsg,
   invalidInputErrMsg,
   genericErrMsg,
-  //invalidWithdrawErrMsg,
   sslSuccessfulMessage,
   sslErrorMessage,
   SSLToken,
   depositCapError
 } from './constants'
-import { notify, truncateBigNumber, truncateBigString, commafy, withdrawBigString } from '../../utils'
+import { notify, truncateBigNumber, truncateBigString, withdrawBigString } from '../../utils'
 import useBreakPoint from '../../hooks/useBreakPoint'
 import { ActionModal } from './ActionModal'
 import BN from 'bn.js'
@@ -387,7 +386,7 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
   const renderStatsAsZero = useCallback(
     (token: string | undefined) => (
       <div tw="text-right dark:text-grey-1 text-grey-2 font-semibold text-regular">
-        <div>0.00 {token}</div>
+        <div>00.00 {token}</div>
       </div>
     ),
     []
@@ -477,8 +476,8 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
               value={
                 totalEarned > 0 ? (
                   <div tw="text-right dark:text-grey-8 text-black-4 font-semibold text-regular">
-                    <div>{totalEarned.toFixed(4)}</div>
-                    <div tw="dark:text-grey-1 text-grey-2">(${totalEarnedInUSD?.toFixed(2)} USD)</div>
+                    <div>{truncateBigNumber(totalEarned)}</div>
+                    <div tw="dark:text-grey-1 text-grey-2">(${truncateBigNumber(totalEarnedInUSD)} USD)</div>
                   </div>
                 ) : (
                   renderStatsAsZero(coin?.token)
@@ -490,8 +489,8 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
               value={
                 claimableReward > 0 ? (
                   <div tw="text-right dark:text-grey-8 text-black-4 font-semibold text-regular">
-                    <div>{commafy(claimableReward, 4)}</div>
-                    <div tw="dark:text-grey-1 text-grey-2">(${commafy(claimableRewardInUSD, 2)} USD)</div>
+                    <div>{truncateBigNumber(claimableReward)}</div>
+                    <div tw="dark:text-grey-1 text-grey-2">(${truncateBigNumber(claimableRewardInUSD)} USD)</div>
                   </div>
                 ) : (
                   renderStatsAsZero(coin?.token)
@@ -556,8 +555,8 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
               <div
                 onClick={() =>
                   modeOfOperation === ModeOfOperation.DEPOSIT
-                    ? setDepositAmount(userTokenBalance ? '0.01' : '0')
-                    : setWithdrawAmount(userDepositedAmount ? '0.01' : '0')
+                    ? setDepositAmount(userTokenBalance ? '00.01' : '0')
+                    : setWithdrawAmount(userDepositedAmount ? '00.01' : '0')
                 }
                 tw="font-bold text-regular text-grey-1 dark:text-grey-2 ml-3 cursor-pointer"
               >
@@ -657,7 +656,7 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
               totalEarned ? (
                 <div tw="text-right">
                   <span tw="dark:text-grey-8 text-black-4 font-semibold text-regular">
-                    {`${commafy(totalEarned, 4)} ($${commafy(totalEarnedInUSD, 2)} USD)`}
+                    {`${truncateBigNumber(totalEarned)} ($${truncateBigNumber(totalEarnedInUSD)} USD)`}
                   </span>
                 </div>
               ) : (
@@ -677,13 +676,13 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
                 claimableReward > 0 ? (
                   <div tw="text-right">
                     <span tw="dark:text-grey-8 text-black-4 font-semibold text-regular">
-                      {`${commafy(claimableReward, 4)} ($${commafy(claimableRewardInUSD, 2)} USD)`}
+                      {`${truncateBigNumber(claimableReward)} ($${truncateBigNumber(claimableRewardInUSD)} USD)`}
                     </span>
                   </div>
                 ) : (
                   <div tw="text-right">
                     <span tw="dark:text-grey-1 text-grey-2 font-semibold text-regular">
-                      0.00 {coin?.token} ($0.00 USD)
+                      00.00 {coin?.token} ($00.00 USD)
                     </span>
                   </div>
                 )

--- a/src/pages/FarmV3/ExpandedView.tsx
+++ b/src/pages/FarmV3/ExpandedView.tsx
@@ -555,7 +555,7 @@ export const ExpandedView: FC<{ isExpanded: boolean; coin: SSLToken; userDeposit
               <div
                 onClick={() =>
                   modeOfOperation === ModeOfOperation.DEPOSIT
-                    ? setDepositAmount(userTokenBalance ? '00.01' : '0.0')
+                    ? setDepositAmount(userTokenBalance ? '00.01' : '0')
                     : setWithdrawAmount(userDepositedAmount ? '00.01' : '0')
                 }
                 tw="font-bold text-regular text-grey-1 dark:text-grey-2 ml-3 cursor-pointer"

--- a/src/pages/FarmV3/FarmTable.tsx
+++ b/src/pages/FarmV3/FarmTable.tsx
@@ -170,7 +170,7 @@ export const FarmTable: FC = () => {
     const count = sslData.reduce((accumulator, data) => {
       const amountInNative = filteredLiquidityAccounts[data?.mint?.toBase58()]?.amountDeposited?.toString()
       const amountInUSD = truncateBigString(amountInNative, data?.mintDecimals)
-      if (amountInUSD && amountInUSD !== '0.00') {
+      if (amountInUSD && amountInUSD !== '00.00') {
         return accumulator + 1
       }
       return accumulator
@@ -311,6 +311,8 @@ export const FarmTable: FC = () => {
     })
     return claimableRewardObj
   }, [allPoolSslData, rewards])
+
+  console.log('show values', numberOfCoinsDeposited, showDeposited, searchTokens?.length, filteredTokens)
 
   return (
     <WRAPPER>
@@ -667,8 +669,8 @@ const FarmTokenContent: FC<{
 
   const showToggleFilteredTokens: boolean = useMemo(() => {
     if (!showDeposited) return true
-    else if (showDeposited && userDepositedAmountUI !== '0.00') return true
-    else if (showDeposited && userDepositedAmountUI === '0.00') return false
+    else if (showDeposited && userDepositedAmountUI !== '00.00') return true
+    else if (showDeposited && userDepositedAmountUI === '00.00') return false
   }, [showDeposited, userDepositedAmount])
 
   // const openStatsModal = (e) => {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -213,29 +213,43 @@ export const truncateBigNumber = (bigNumber: number): string | number => {
   try {
     if (bigNumber >= 1000000000) {
       const nArray = (bigNumber / 1000000000).toString().split('.')
-      const beforeDecimal = nArray[0]
+      let beforeDecimal = nArray[0]
+      if (beforeDecimal.length === 1) beforeDecimal = '0' + beforeDecimal
       let afterDecimal = nArray.length > 1 ? nArray[1] : null
-      if (!afterDecimal || afterDecimal === '0') afterDecimal = null
-      else if (afterDecimal.length > 2) afterDecimal = afterDecimal.slice(0, 2)
+      if (!afterDecimal || afterDecimal === '0') afterDecimal = '00'
+      else if (afterDecimal.length >= 2) afterDecimal = afterDecimal.slice(0, 2)
+      else if (afterDecimal.length < 2) afterDecimal = afterDecimal + '0'
       return beforeDecimal + (afterDecimal ? '.' + afterDecimal : '') + 'B'
     }
     if (bigNumber >= 1000000) {
       const nArray = (bigNumber / 1000000).toString().split('.')
-      const beforeDecimal = nArray[0]
+      let beforeDecimal = nArray[0]
+      if (beforeDecimal.length === 1) beforeDecimal = '0' + beforeDecimal
       let afterDecimal = nArray.length > 1 ? nArray[1] : null
-      if (!afterDecimal || afterDecimal === '0') afterDecimal = null
-      else if (afterDecimal.length > 2) afterDecimal = afterDecimal.slice(0, 2)
+      if (!afterDecimal || afterDecimal === '0') afterDecimal = '00'
+      else if (afterDecimal.length >= 2) afterDecimal = afterDecimal.slice(0, 2)
+      else if (afterDecimal.length < 2) afterDecimal = afterDecimal + '0'
       return beforeDecimal + (afterDecimal ? '.' + afterDecimal : '') + 'M'
     }
     if (bigNumber >= 1000) {
       const nArray = (bigNumber / 1000).toString().split('.')
-      const beforeDecimal = nArray[0]
+      let beforeDecimal = nArray[0]
+      if (beforeDecimal.length === 1) beforeDecimal = '0' + beforeDecimal
       let afterDecimal = nArray[1]
-      if (!afterDecimal || afterDecimal === '0') afterDecimal = null
-      else if (afterDecimal.length > 2) afterDecimal = afterDecimal.slice(0, 2)
+      if (!afterDecimal || afterDecimal === '0') afterDecimal = '00'
+      else if (afterDecimal.length >= 2) afterDecimal = afterDecimal.slice(0, 2)
+      else if (afterDecimal.length < 2) afterDecimal = afterDecimal + '0'
       return beforeDecimal + (afterDecimal ? '.' + afterDecimal : '') + 'K'
+    } else {
+      const nArray = bigNumber.toString().split('.')
+      let beforeDecimal = nArray[0]
+      if (beforeDecimal.length === 1) beforeDecimal = '0' + beforeDecimal
+      let afterDecimal = nArray.length > 1 ? nArray[1] : null
+      if (!afterDecimal || afterDecimal === '0') afterDecimal = '00'
+      else if (afterDecimal.length >= 2) afterDecimal = afterDecimal.slice(0, 2)
+      else if (afterDecimal.length < 2) afterDecimal = afterDecimal + '0'
+      return beforeDecimal + (afterDecimal ? '.' + afterDecimal : '')
     }
-    return Number(bigNumber.toFixed(2))
   } catch (error) {
     console.log('BIG NUM ERROR', bigNumber)
   }
@@ -252,24 +266,26 @@ export const truncateBigNumber = (bigNumber: number): string | number => {
 export const truncateBigString = (nativeString: string, mintDecimals: number): string => {
   // eslint-disable-next-line max-len
   if (!nativeString || nativeString === null || nativeString === '0' || typeof nativeString !== 'string')
-    return '0.00'
+    return '00.00'
 
   let usdString = ''
+  let before = ''
   const nativeStringLen = nativeString.length
   if (nativeStringLen > mintDecimals) {
+    if (nativeStringLen - mintDecimals === 1)
+      before = '0' + nativeString.substring(0, nativeStringLen - mintDecimals)
+    else before = nativeString.substring(0, nativeStringLen - mintDecimals)
     usdString =
-      nativeString.substring(0, nativeStringLen - mintDecimals) +
-      '.' +
-      nativeString.substring(nativeStringLen - mintDecimals, nativeStringLen - mintDecimals + 2)
+      before + '.' + nativeString.substring(nativeStringLen - mintDecimals, nativeStringLen - mintDecimals + 2)
   } else {
     let i = 0
-    let result = '0.'
+    let result = '00.'
     while (i < mintDecimals - nativeStringLen) {
       result += '0'
       i++
     }
     usdString = result + nativeString
-    usdString = usdString?.substring(0, 4)
+    usdString = usdString?.substring(0, 5)
   }
   const decimalIndex = usdString?.indexOf('.')
   const beforeDecimal = usdString?.substring(0, decimalIndex)
@@ -277,18 +293,22 @@ export const truncateBigString = (nativeString: string, mintDecimals: number): s
 
   try {
     if (length > 9) {
-      const resultStr =
-        beforeDecimal.substring(0, length - 9) + '.' + beforeDecimal.substring(length - 9, length - 9 + 2)
+      if (length - 9 === 1) before = '0' + beforeDecimal.substring(0, length - 9)
+      else before = beforeDecimal.substring(0, length - 9)
+      const resultStr = before + '.' + beforeDecimal.substring(length - 9, length - 9 + 2)
       return resultStr + 'B'
     }
     if (length > 6) {
-      const resultStr =
-        beforeDecimal.substring(0, length - 6) + '.' + beforeDecimal.substring(length - 6, length - 6 + 2)
+      if (length - 6 === 1) before = '0' + beforeDecimal.substring(0, length - 6)
+      else before = beforeDecimal.substring(0, length - 6)
+      const resultStr = before + '.' + beforeDecimal.substring(length - 6, length - 6 + 2)
       return resultStr + 'M'
     }
     if (length > 3) {
-      const resultStr =
-        beforeDecimal.substring(0, length - 3) + '.' + beforeDecimal.substring(length - 3, length - 3 + 2)
+      let before = ''
+      if (length - 3 === 1) before = '0' + beforeDecimal.substring(0, length - 3)
+      else before = beforeDecimal.substring(0, length - 3)
+      const resultStr = before + '.' + beforeDecimal.substring(length - 3, length - 3 + 2)
       return resultStr + 'K'
     }
     return usdString
@@ -304,7 +324,8 @@ export const truncateBigString = (nativeString: string, mintDecimals: number): s
   the user input string has a decimal or not. If the user input string has a decimal if block will run, otherwise 
   else block will run.
   For example: For 1.24 SOL input, the if block will run and append (9-2-1 = 6) zeroes to the input string where:
-  9 -> mintDecimals, 2 -> afterdecimal length(24), 1(less than sign, so the while loop won't iterate for the 7th time).
+  9 -> mintDecimals, 2 -> afterdecimal length(24 -> length is 2), 1(less than sign, so the while loop 
+  won't iterate for the 7th time).
   If there are no decimals, then simply append mint - 1 zeroes. For example: For 1 SOL input, the else block will 
   run and append (9 - 1) = 8 zeroes.
 */


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
The change to be tested is: All the numbers are fixed to have 2 decimal places after the decimal point and minimum 2 decimal places before the decimal point. For example, 1.2$ is represented as 01.20$, 22.4$ is represented as 22.40$. The numbers before the decimal point can obviously be greater than 2, for example, 300.3$ is represented as 300.30$ but the minimum digits before decimal will always be 2.

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

