### PR TITLE
fix: display opposite side in trade history if the trader is a maker

### DIFF
--- a/src/pages/Account/components/Trades.tsx
+++ b/src/pages/Account/components/Trades.tsx
@@ -104,13 +104,13 @@ const HISTORY = styled.div`
     font-size: 15px;
     font-weight: 600;
   }
-  .Bid {
+  .Long {
     color: #80ce00;
   }
   .filled {
     color: #80ce00;
   }
-  .Ask {
+  .Short {
     color: #f35355;
   }
 `
@@ -162,6 +162,15 @@ const Trades: FC = () => {
     }
   }, [connected, publicKey, pagination, traderInfo.traderRiskGroupKey])
 
+  // if the trader is the maker side displayed should be the opposite
+  const getDisplayTradeSide = (trade: any) => {
+    if (trade.taker == traderInfo.traderRiskGroupKey.toString()) {
+      return trade.side === 'Bid' ? 'Long' : 'Short'
+    } else {
+      return trade.side === 'Ask' ? 'Long' : 'Short'
+    }
+  }
+
   return (
     <WRAPPER>
       {depositWithdrawModal && (
@@ -198,7 +207,7 @@ const Trades: FC = () => {
                     <img src={`${assetIcon}`} alt="SOL icon" />
                     <span>{selectedCrypto.pair}</span>
                   </div>
-                  <span className={trade.side}>{trade.side === 'Bid' ? 'Long' : 'Short'}</span>
+                  <span className={getDisplayTradeSide(trade)}>{getDisplayTradeSide(trade)}</span>
                   <span>{trade.qty.toFixed(3)} SOL</span>
                   <span>${(trade.qty * trade.price).toFixed(2)}</span>
                   <span>${trade.price.toFixed(2)}</span>


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
The api to return filled trades is now returning both maker and taker trades, to display the side correctly we need to display the opposite side if the trader in the trade object is a maker.
## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
