### PR TITLE
Half/Max buttons disabled when ustaking

### DIFF
--- a/src/components/rewards/v2/leftPanel/RewardsInput.tsx
+++ b/src/components/rewards/v2/leftPanel/RewardsInput.tsx
@@ -45,6 +45,7 @@ export default function RewardsInput({
   useEffect(() => {
     onInputChange(inputValue)
   }, [inputValue])
+  const disabled = isStakeSelected ? userGoFxBalance.uiAmount <= 0.0 : totalStaked <= 0.0
   return (
     <InputGroup
       onClick={focusInput}
@@ -54,24 +55,18 @@ export default function RewardsInput({
           <Button
             variant={'ghost'}
             onClick={handleHalf}
-            className={cn(
-              `p-1.5`,
-              userGoFxBalance.uiAmount > 0.0 && `text-text-blue dark:text-text-darkmode-primary`
-            )}
+            className={cn(`p-1.5`, !disabled && `text-text-blue dark:text-text-darkmode-primary`)}
             size={'sm'}
-            disabled={userGoFxBalance.uiAmount <= 0.0}
+            disabled={disabled}
           >
             Half
           </Button>
           <Button
             variant={'ghost'}
             onClick={handleMax}
-            className={cn(
-              `p-1.5`,
-              userGoFxBalance.uiAmount > 0.0 && `text-text-blue dark:text-text-darkmode-primary`
-            )}
+            className={cn(`p-1.5`, !disabled && `text-text-blue dark:text-text-darkmode-primary`)}
             size={'sm'}
-            disabled={userGoFxBalance.uiAmount <= 0.0}
+            disabled={disabled}
           >
             Max
           </Button>


### PR DESCRIPTION
fix max/half buttons disabled for unstake

## Description
Half Max buttons disabled when unstaking
## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
