### PR TITLE
Load asks/bids data via rpc if db result is outdated

### DIFF
--- a/src/pages/TradeV3/perps/utils.tsx
+++ b/src/pages/TradeV3/perps/utils.tsx
@@ -476,12 +476,12 @@ export const convertToFractional = (amount: string): Fractional => {
   return new Fractional({ m: new anchor.BN(newM), exp: new anchor.BN(newdigitsAfterDecimal) })
 }
 
-export const loadBidsSlab = async (connection: Connection, bidAccount: string) => {
-  const bidsInfo = await connection.getAccountInfo(new PublicKey(bidAccount), 'finalized')
-  if (!bidsInfo?.data) {
-    throw new Error('Invalid asks account')
+export const loadSlab = async (connection: Connection, account: string) => {
+  const accountInfo = await connection.getAccountInfo(new PublicKey(account), 'finalized')
+  if (!accountInfo?.data) {
+    throw new Error('Invalid asks/bids account')
   }
-  return Slab.deserialize(bidsInfo.data, 40)
+  return Slab.deserialize(accountInfo.data, 40)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/pages/TradeV3/perps/utils.tsx
+++ b/src/pages/TradeV3/perps/utils.tsx
@@ -475,13 +475,19 @@ export const convertToFractional = (amount: string): Fractional => {
   const newM = Number(beforeDecimal + maxFour)
   return new Fractional({ m: new anchor.BN(newM), exp: new anchor.BN(newdigitsAfterDecimal) })
 }
+const SLAB_DESERIALIZATION_OFFSET = 40; 
 
 export const loadSlab = async (connection: Connection, account: string) => {
+  try {
   const accountInfo = await connection.getAccountInfo(new PublicKey(account), 'finalized')
-  if (!accountInfo?.data) {
-    throw new Error('Invalid asks/bids account')
+    if (!accountInfo?.data) {
+      throw new Error(`No data found for the account ${account}`);
+    }
+    return Slab.deserialize(accountInfo.data, SLAB_DESERIALIZATION_OFFSET);
+  } catch (error) {
+    console.error(`Failed to load or parse account ${account}:`, error);
+    throw new Error(`Failed to load or parse account ${account}`);
   }
-  return Slab.deserialize(accountInfo.data, 40)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description
Fallback to rpc for loading orderbook asks and bids if results retrieved from database were last updated > 60 seconds ago. 

[Clickup task](https://app.clickup.com/t/86cv39gjj)

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
