### PR TITLE
Fix Farm Deposit/Withdraw not correctly disabling allowing for error states

### DIFF
--- a/src/pages/FarmV3/FarmTableComponents/FarmTableBalanceItem.tsx
+++ b/src/pages/FarmV3/FarmTableComponents/FarmTableBalanceItem.tsx
@@ -557,14 +557,14 @@ const CollapsibleContent: FC<{
     new BigNumber(userDepositedAmount.toString())
       .div(new BigNumber(10 ** coin?.mintDecimals))
       .gte(new BigNumber(MIN_AMOUNT_WITHDRAW))
-
   const minMaxDisabled = modeOfOperation === ModeOfOperation.DEPOSIT ? !canDeposit : !canWithdraw
-
   const disabled =
     !connected ||
     operationPending ||
     isButtonLoading ||
-    (modeOfOperation === ModeOfOperation.DEPOSIT ? !canDeposit : !canWithdraw)
+    (modeOfOperation === ModeOfOperation.DEPOSIT
+      ? !canDeposit || userTokenBalance.lt(new BigNumber(depositAmount))
+      : !canWithdraw || userDepositedAmount.div(new BigNumber(10 ** coin?.mintDecimals)).lt(withdrawAmount))
   const canClaim = claimableReward.gte(MIN_AMOUNT_CLAIM)
 
   return (


### PR DESCRIPTION
fix: withdraw/deposit buttons enabled when trying to commit values
## Description

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] The related ClickUp task has been linked to this PR
- [x] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
