### PR TITLE
Settings provider rework

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const SOL_TX_STATUS = {
   FINALIZED: 'finalized',
   PROCESSED: 'processed',
   CONFIRMED: 'confirmed'
-} as const;
+} as const
 
 export const CURRENT_SUPPORTED_TOKEN_LIST = new Set(['SOL', 'USDC', 'SRM', 'ETH', 'GMT', 'mSOL', 'APT'])
 export const FARM_SUPPORTED_TOKEN_LIST = new Set(['GOFX'])

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const SOL_TX_STATUS = {
   FINALIZED: 'finalized',
   PROCESSED: 'processed',
   CONFIRMED: 'confirmed'
-}
+} as const;
 
 export const CURRENT_SUPPORTED_TOKEN_LIST = new Set(['SOL', 'USDC', 'SRM', 'ETH', 'GMT', 'mSOL', 'APT'])
 export const FARM_SUPPORTED_TOKEN_LIST = new Set(['GOFX'])


### PR DESCRIPTION
<!-- **TITLE FORMATTING** - ClickUp title “UI: Farm - Create Header” becomes “Farm: Create Header” as title of pull request -->

## Description

I found out that settings provider do manipulating with localstorage multiple times. It can do it just on one change. Also found out that useMemos manipulates with states, what is incorrect.

Also fixed naming and recalculation for settings component

## How has this been tested?

## Types of changes

- [x] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation

## Screenshots or Loom Video (optional):
