### PR TITLE
feat: update priority fees when network is congested

### DIFF
--- a/src/components/footer/NetworkStatus.tsx
+++ b/src/components/footer/NetworkStatus.tsx
@@ -36,14 +36,14 @@ const NetworkStatus: FC = () => {
         }
       case 1:
         return {
-          networkStatus: 'Degraded',
+          networkStatus: 'Congested',
           textColor: 'text-background-yellow',
           bgColor: 'bg-background-yellow',
           description: STATUS.DEGRADED
         }
       case 2:
         return {
-          networkStatus: 'Congested',
+          networkStatus: 'Degraded',
           textColor: 'text-background-red',
           bgColor: 'bg-background-red',
           description: STATUS.CONGESTED

--- a/src/components/footer/PriorityFee.tsx
+++ b/src/components/footer/PriorityFee.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useState } from 'react'
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Button,
   cn,
@@ -19,10 +19,12 @@ import { PriorityFeeName, useConnectionConfig, useDarkMode } from '@/context'
 import RadioOptionGroup from '@/components/common/RadioOptionGroup'
 import useBreakPoint from '@/hooks/useBreakPoint'
 import useBoolean from '@/hooks/useBoolean'
+import useNetworkStatus from '@/hooks/useNetworkStatus'
 
 const PriorityFee: FC = () => {
   const { mode } = useDarkMode()
   const { priorityFee, setPriorityFee } = useConnectionConfig()
+  const { status } = useNetworkStatus()
   const [localPriorityFee, setLocalPriorityFee] = useState<PriorityFeeName>(priorityFee)
   const { isMobile } = useBreakPoint()
   const [isOpen, setIsOpen] = useBoolean(false)
@@ -42,6 +44,13 @@ const PriorityFee: FC = () => {
     }
   }, [priorityFee])
   const saveDisabled = priorityFee === localPriorityFee
+
+  useEffect(() => {
+    if (status >= 1) {
+      setPriorityFee('Turbo')
+    }
+  }, [status])
+
   const handleSave = useCallback(() => {
     setIsOpen.off()
     if (priorityFee !== localPriorityFee) {


### PR DESCRIPTION
This Pr adds functionality to automatically change priority fees if the network is congested

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation
