### PR TITLE
feat: rewrite pool list and auto load pools on scroll

### DIFF
--- a/src/context/gamma.tsx
+++ b/src/context/gamma.tsx
@@ -83,6 +83,7 @@ interface GAMMADataModel {
   setModeOfOperation: Dispatch<SetStateAction<string>>
   page: number
   setPage: Dispatch<SetStateAction<number>>
+  totalPoolCount: number,
   tokenList: TokenListToken[]
   isLoadingTokenList: boolean
   updateTokenList: ({ page, pageSize, searchValue }: {
@@ -181,6 +182,7 @@ export const GammaProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [isLoadingTokenList, setIsLoadingTokenList] = useState(false)
   const [isLoadingPools, setIsLoadingPools] = useBoolean(false)
   const [poolPage, setPoolPage] = useState(1)
+  const [totalPoolCount, setTotalPoolCount] = useState(0);
   const [poolsHasMoreData, setPoolsHasMoreData] = useState(true)
   const sortConfig = useMemo(() => GAMMA_SORT_CONFIG_MAP.get(currentSort) ?? GAMMA_SORT_CONFIG[0], [currentSort])
   const [selectedCardLiquidityAcc, setSelectedCardLiquidityAcc] = useState<any>({})
@@ -381,6 +383,8 @@ export const GammaProvider: FC<{ children: ReactNode }> = ({ children }) => {
       .then((poolsData: GAMMAPoolsResponse) => {
         if (poolsData && poolsData.success) {
           setPoolsHasMoreData(poolsData.data.totalPages > poolsData.data.currentPage)
+          setPoolPage(poolsData.data.currentPage);
+          setTotalPoolCount(poolsData.data.totalItems);
           const existingPools = append ? pools : []
           const existingPoolsMap = new Map(
             existingPools.map((pool) => [`${pool.mintA.address}_${pool.mintB.address}`, pool])
@@ -405,7 +409,7 @@ export const GammaProvider: FC<{ children: ReactNode }> = ({ children }) => {
           setPools(updatedPools)
         }
       })
-      .finally(() => setTimeout(() => setIsLoadingPools.off(), 2000))
+      .finally(() => setIsLoadingPools.off())
   }
 
   useEffect(() => {
@@ -432,7 +436,7 @@ export const GammaProvider: FC<{ children: ReactNode }> = ({ children }) => {
   }, [currentPoolType])
   useEffect(() => {
     updatePools({ page: poolPage, pageSize: POOL_LIST_PAGE_SIZE, poolType: currentPoolType.type })
-  }, [poolPage, sortConfig, viewRange])
+  }, [sortConfig, viewRange])
 
   useEffect(() => {
 
@@ -673,6 +677,7 @@ export const GammaProvider: FC<{ children: ReactNode }> = ({ children }) => {
         isLoadingPools,
         poolPage,
         setPoolPage,
+        totalPoolCount,
         isSearchActive,
         filteredPools,
         updatePools,

--- a/src/pages/FarmV4/FarmItems.tsx
+++ b/src/pages/FarmV4/FarmItems.tsx
@@ -1,10 +1,11 @@
 import { FC, useMemo } from 'react'
 import NoResultsFound from './NoResultsFound'
 import { useGamma, useRewardToggle } from '@/context'
-import { POOL_TYPE } from '@/pages/FarmV4/constants'
 import FarmItemsMigrate from '@/pages/FarmV4/FarmItemsMigrate'
 import FarmItemsLite from '@/pages/FarmV4/FarmItemsLite'
 import FarmItemsPro from '@/pages/FarmV4/FarmItemsPro'
+import { Button } from 'gfx-component-lib'
+import { POOL_LIST_PAGE_SIZE, POOL_TYPE } from '@/pages/FarmV4/constants'
 
 export const noPoolsFound = {
   title: 'Oops, no pools found',
@@ -28,6 +29,9 @@ const FarmItems: FC<{
     currentPoolType,
     searchTokens,
     showDeposited,
+    updatePools,
+    poolPage,
+    poolsHasMoreData
   } = useGamma()
   const { isProMode } = useRewardToggle()
   const isSearchActive = useMemo(() => searchTokens.length > 0, [searchTokens])
@@ -113,6 +117,21 @@ const FarmItems: FC<{
         openPositionImages={openPositionImages}
         openPositionsAcrossPrograms={openPositionsAcrossPrograms}
       />
+      }
+      {!isProMode && ((!(numberOfTokensDeposited === 0 && showDeposited) || filteredPools.length !== 0) && 
+      currentPoolType.type != 'migrate') && poolsHasMoreData &&
+        <Button
+          className="cursor-pointer rounded-full border-[1.5px] border-solid border-purple-5
+            dark:bg-black-1 dark:text-white bg-grey-5 mx-auto font-bold text-regular text-black-4"
+          variant={'primary'}
+          onClick={() => updatePools({
+            page: poolPage + 1,
+            pageSize: POOL_LIST_PAGE_SIZE,
+            poolType: currentPoolType.type
+          })}
+        >
+          Load More
+        </Button>
       }
     </div>
   )

--- a/src/pages/FarmV4/FarmItems.tsx
+++ b/src/pages/FarmV4/FarmItems.tsx
@@ -1,8 +1,7 @@
 import { FC, useMemo } from 'react'
 import NoResultsFound from './NoResultsFound'
 import { useGamma, useRewardToggle } from '@/context'
-import { Button } from 'gfx-component-lib'
-import { POOL_LIST_PAGE_SIZE, POOL_TYPE } from '@/pages/FarmV4/constants'
+import { POOL_TYPE } from '@/pages/FarmV4/constants'
 import FarmItemsMigrate from '@/pages/FarmV4/FarmItemsMigrate'
 import FarmItemsLite from '@/pages/FarmV4/FarmItemsLite'
 import FarmItemsPro from '@/pages/FarmV4/FarmItemsPro'
@@ -29,9 +28,6 @@ const FarmItems: FC<{
     currentPoolType,
     searchTokens,
     showDeposited,
-    updatePools,
-    poolPage,
-    poolsHasMoreData
   } = useGamma()
   const { isProMode } = useRewardToggle()
   const isSearchActive = useMemo(() => searchTokens.length > 0, [searchTokens])
@@ -117,21 +113,6 @@ const FarmItems: FC<{
         openPositionImages={openPositionImages}
         openPositionsAcrossPrograms={openPositionsAcrossPrograms}
       />
-      }
-      {((!(numberOfTokensDeposited === 0 && showDeposited) || filteredPools.length !== 0)
-          && currentPoolType.type != 'migrate') && poolsHasMoreData &&
-        <Button
-          className="cursor-pointer rounded-full border-[1.5px] border-solid border-purple-5
-            dark:bg-black-1 dark:text-white bg-grey-5 mx-auto font-bold text-regular text-black-4"
-          variant={'primary'}
-          onClick={() => updatePools({
-            page: poolPage + 1,
-            pageSize: POOL_LIST_PAGE_SIZE,
-            poolType: currentPoolType.type
-          })}
-        >
-          Load More
-        </Button>
       }
     </div>
   )

--- a/src/pages/FarmV4/FarmItemsPro.tsx
+++ b/src/pages/FarmV4/FarmItemsPro.tsx
@@ -2,13 +2,13 @@ import { FC } from 'react'
 import FarmItemsProSort from '@/pages/FarmV4/FarmItemsProSort'
 import FarmRow from '@/pages/FarmV4/FarmRow'
 import { GAMMAPoolWithUserLiquidity } from '@/types/gamma'
-import WindowingContainer from '@/pages/FarmV4/WindowingContainer'
+import InfiniteProPoolList from '@/pages/FarmV4/InfiniteProPoolList'
 
 const FarmItemsPro: FC = () => (
   <>
     <FarmItemsProSort />
     <div>
-      <WindowingContainer
+      <InfiniteProPoolList
         itemPadding={15}
         render={(pool: GAMMAPoolWithUserLiquidity, i) => (
           <FarmRow pool={pool} key={`${pool?.mintA.name}-${pool?.mintB.name}-${i}`} />

--- a/src/pages/FarmV4/FarmItemsPro.tsx
+++ b/src/pages/FarmV4/FarmItemsPro.tsx
@@ -1,32 +1,21 @@
 import { FC } from 'react'
 import FarmItemsProSort from '@/pages/FarmV4/FarmItemsProSort'
-import FarmRow, { FarmRowLoader } from '@/pages/FarmV4/FarmRow'
+import FarmRow from '@/pages/FarmV4/FarmRow'
 import { GAMMAPoolWithUserLiquidity } from '@/types/gamma'
 import WindowingContainer from '@/pages/FarmV4/WindowingContainer'
-import { useGamma } from '@/context'
 
-const FarmItemsPro: FC = () => {
-  const { filteredPools, isLoadingPools } = useGamma()
-  return (
-    <>
-      <FarmItemsProSort />
-      <div>
-        {isLoadingPools ? <div className={'flex flex-col gap-[15px] mt-[15px]'}>
-          <FarmRowLoader />
-          <FarmRowLoader />
-          <FarmRowLoader />
-          <FarmRowLoader />
-        </div> : <WindowingContainer
-          itemPadding={15}
-          items={filteredPools}
-          render={(pool: GAMMAPoolWithUserLiquidity, i) => (
-            <FarmRow pool={pool} key={`${pool?.mintA.name}-${pool?.mintB.name}-${i}`} />
-          )}
-        />}
-      </div>
-    </>
-  )
-}
-
+const FarmItemsPro: FC = () => (
+  <>
+    <FarmItemsProSort />
+    <div>
+      <WindowingContainer
+        itemPadding={15}
+        render={(pool: GAMMAPoolWithUserLiquidity, i) => (
+          <FarmRow pool={pool} key={`${pool?.mintA.name}-${pool?.mintB.name}-${i}`} />
+        )}
+      />
+    </div>
+  </>
+)
 
 export default FarmItemsPro

--- a/src/pages/FarmV4/InfiniteProPoolList.tsx
+++ b/src/pages/FarmV4/InfiniteProPoolList.tsx
@@ -6,20 +6,15 @@ import { POOL_LIST_PAGE_SIZE } from './constants'
 import { FarmRowLoader } from './FarmRow'
 import { CSSProperties } from 'styled-components'
 
-type WindowContainerProps<T> = {
-  rootElement?: HTMLElement
+type InfiniteProPoolListProps<T> = {
   render: (item: T, index: number) => JSX.Element
-  itemClassName?: string
   itemPadding?: number
 } & HTMLAttributes<HTMLDivElement>
 
-const WindowingContainer: FC<WindowContainerProps<unknown>> = ({
+const InfiniteProPoolList: FC<InfiniteProPoolListProps<unknown>> = ({
   render,
-  className,
   itemPadding: ITEM_PADDING = 8,
-  ...rest
 }): JSX.Element => {
-  const ref = useRef<HTMLDivElement>(null)
   const {
     filteredPools: items,
     currentSort,
@@ -75,7 +70,6 @@ const WindowingContainer: FC<WindowContainerProps<unknown>> = ({
   const windowHeight = Math.min(10, totalPoolCount) * 60
 
   return (
-    <div className={className} ref={ref} {...rest}>
       <InfiniteLoader isItemLoaded={isItemLoaded} itemCount={itemCount} loadMoreItems={loadMoreItems}>
         {({ onItemsRendered, ref }) => (
           <FixedSizeList
@@ -90,8 +84,7 @@ const WindowingContainer: FC<WindowContainerProps<unknown>> = ({
           </FixedSizeList>
         )}
       </InfiniteLoader>
-    </div>
   )
 }
 
-export default WindowingContainer
+export default InfiniteProPoolList

--- a/src/pages/FarmV4/WindowingContainer.tsx
+++ b/src/pages/FarmV4/WindowingContainer.tsx
@@ -1,63 +1,95 @@
-import React, { FC, HTMLAttributes, useLayoutEffect, useRef, useState } from 'react'
+import { useGamma } from '@/context'
+import React, { FC, HTMLAttributes, useEffect, useRef } from 'react'
+import InfiniteLoader from 'react-window-infinite-loader'
+import { FixedSizeList } from 'react-window'
+import { POOL_LIST_PAGE_SIZE } from './constants'
+import { FarmRowLoader } from './FarmRow'
+import { CSSProperties } from 'styled-components'
 
 type WindowContainerProps<T> = {
   rootElement?: HTMLElement
-  items: T[]
   render: (item: T, index: number) => JSX.Element
   itemClassName?: string
   itemPadding?: number
 } & HTMLAttributes<HTMLDivElement>
 
 const WindowingContainer: FC<WindowContainerProps<unknown>> = ({
-  items,
   render,
-  rootElement,
   className,
-  itemClassName,
   itemPadding: ITEM_PADDING = 8,
   ...rest
 }): JSX.Element => {
   const ref = useRef<HTMLDivElement>(null)
-  const [itemHeight, setItemHeight] = useState(0)
+  const {
+    filteredPools: items,
+    currentSort,
 
-  useLayoutEffect(() => {
-    const elementToTarget = rootElement || ref.current
-    if (!elementToTarget) return
+    updatePools,
+    poolPage,
+    currentPoolType,
 
-    const calculateHeights = () => {
-      if (!elementToTarget) return
-      const firstItem = elementToTarget.querySelector('[data-item]') as HTMLElement
-      if (firstItem) {
-        setItemHeight(firstItem.offsetHeight + ITEM_PADDING)
+    isLoadingPools,
+    totalPoolCount
+  } = useGamma()
+
+  const itemCount = totalPoolCount
+
+  const infiniteLoaderRef = useRef(null)
+  const hasMountedRef = useRef(false)
+
+  const isItemLoaded = (index) => !!items[index]
+
+  // Each time the sort prop changed we called the method resetloadMoreItemsCache to clear the cache
+  useEffect(() => {
+    // We only need to reset cached items when sort order changes.
+    // This effect will run on mount too; there's no need to reset in that case.
+    if (hasMountedRef.current) {
+      if (infiniteLoaderRef.current) {
+        infiniteLoaderRef.current.resetloadMoreItemsCache()
       }
     }
+    hasMountedRef.current = true
+  }, [currentSort])
 
-    calculateHeights()
-  }, [items, rootElement])
+  const loadMoreItems = () => {
+    if (isLoadingPools) return
+    updatePools({
+      page: poolPage + 1,
+      pageSize: POOL_LIST_PAGE_SIZE,
+      poolType: currentPoolType.type
+    })
+  }
 
-  const windowHeight = Math.min(10, items.length) * itemHeight
+  // Render an item or a loading indicator.
+  const Item = ({ index, style }: { index: number; style: CSSProperties }) => {
+    let content
+    if (!isItemLoaded(index)) {
+      content = <FarmRowLoader />
+    } else {
+      content = render(items[index], index)
+    }
+
+    return <div style={style }>{content}</div>
+  }
+
+  const windowHeight = Math.min(10, totalPoolCount) * 60
 
   return (
-    <div
-      className={className}
-      ref={ref}
-      {...rest}
-      style={{ overflowY: 'scroll', position: 'relative', height: windowHeight }}
-    >
-      {items.map((item, index) => (
-        <div
-          className={itemClassName}
-          key={index}
-          data-item
-          style={{
-            position: 'absolute',
-            top: (index) * itemHeight + ITEM_PADDING,
-            width: '100%'
-          }}
-        >
-          {render(item, index)}
-        </div>
-      ))}
+    <div className={className} ref={ref} {...rest}>
+      <InfiniteLoader isItemLoaded={isItemLoaded} itemCount={itemCount} loadMoreItems={loadMoreItems}>
+        {({ onItemsRendered, ref }) => (
+          <FixedSizeList
+            height={windowHeight}
+            itemSize={60 + ITEM_PADDING}
+            className="List"
+            itemCount={itemCount}
+            onItemsRendered={onItemsRendered}
+            ref={ref}
+          >
+            {Item}
+          </FixedSizeList>
+        )}
+      </InfiniteLoader>
     </div>
   )
 }

--- a/src/pages/FarmV4/constants.tsx
+++ b/src/pages/FarmV4/constants.tsx
@@ -221,7 +221,7 @@ export const GAMMA_SORT_CONFIG_MAP: Map<string, GAMMASortConfig> =
 export type PoolSortId = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8'
 export const BASE_SLIPPAGE = [0.1, 0.5, 1.0]
 export const TOKEN_LIST_PAGE_SIZE = 50
-export const POOL_LIST_PAGE_SIZE = 200
+export const POOL_LIST_PAGE_SIZE = 16
 export const POPULAR_TOKENS = new Set([
   'So11111111111111111111111111111111111111112',
   'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',


### PR DESCRIPTION
This PR refactors pool list in gamma (Pro mode) and adds functionality to automatically load pools after reaching 16th pool.

Also fixes the following bugs
- load more button didn't work
- memory issue when loading more pools

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation
