### PR TITLE
disable swap button when insufficient token balance in swap page

### DIFF
--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -453,7 +453,13 @@ mt-8 flex items-center justify-center
               variant={'primary'}
               colorScheme={'blue'}
               fullWidth
-              disabled={!selectedTokenA || !selectedTokenB || !amountTokenA || !amountTokenB}
+              disabled={
+                !selectedTokenA ||
+                !selectedTokenB ||
+                !amountTokenA ||
+                !amountTokenB ||
+                balance[selectedTokenA?.address].tokenAmount.uiAmount < +amountTokenA
+              }
             >
               Swap
             </Button>


### PR DESCRIPTION
This Pr disables swap button when tokenA balance is lower then amount entered

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation
