### PR TITLE
Consume dynamic fee and cumulative trade fee from the api

### DIFF
--- a/src/pages/FarmV4/DepositWithdrawAccordion.tsx
+++ b/src/pages/FarmV4/DepositWithdrawAccordion.tsx
@@ -8,12 +8,7 @@ import BN from 'bn.js'
 const DepositWithdrawAccordion: FC<{
   withdrawableBalanceA: BN
   withdrawableBalanceB: BN
-  updatedPoolState: any
-}> = ({
-  withdrawableBalanceA,
-  withdrawableBalanceB,
-  updatedPoolState
-}): ReactElement => {
+}> = ({ withdrawableBalanceA, withdrawableBalanceB }): ReactElement => {
   const { selectedCard } = useGamma()
   return (
     <Accordion
@@ -29,7 +24,10 @@ const DepositWithdrawAccordion: FC<{
             <h4>My Position</h4>
           </AccordionTrigger>
           <AccordionContent>
-            <MyPositionStats withdrawableBalanceA={withdrawableBalanceA} withdrawableBalanceB={withdrawableBalanceB} />
+            <MyPositionStats
+              withdrawableBalanceA={withdrawableBalanceA}
+              withdrawableBalanceB={withdrawableBalanceB}
+            />
           </AccordionContent>
         </AccordionItem>
       ) : null}
@@ -38,9 +36,7 @@ const DepositWithdrawAccordion: FC<{
           <h4>Pool Stats</h4>
         </AccordionTrigger>
         <AccordionContent>
-          <PoolStats pool={selectedCard}
-          updatedPoolState={updatedPoolState}
-          />
+          <PoolStats pool={selectedCard} />
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/src/pages/FarmV4/DepositWithdrawSlider.tsx
+++ b/src/pages/FarmV4/DepositWithdrawSlider.tsx
@@ -165,8 +165,8 @@ export const DepositWithdrawSlider: FC = () => {
               lpSupply: decodedAccount.lp_supply,
               protocolFeesToken0: decodedAccount.protocol_fees_token_0,
               protocolFeesToken1: decodedAccount.protocol_fees_token_1,
-              comulativeTradeFeesToken0: decodedAccount.cumulative_trade_fees_token_0,
-              comulativeTradeFeesToken1: decodedAccount.cumulative_trade_fees_token_1,
+              cumulativeTradeFeesToken0: decodedAccount.cumulative_trade_fees_token_0,
+              cumulativeTradeFeesToken1: decodedAccount.cumulative_trade_fees_token_1,
               latestDynamicFeeRate: decodedAccount.latest_dynamic_fee_rate,
               fundFeesToken0: decodedAccount.fund_fees_token_0,
               fundFeesToken1: decodedAccount.fund_fees_token_1,
@@ -192,23 +192,23 @@ export const DepositWithdrawSlider: FC = () => {
         if(Object.keys(selectedCard)?.length > 0){
           const poolIdKey = await getpoolId(selectedCard)
           const accountInfo = await connection.getAccountInfo(poolIdKey)
-            const decodedAccount = POOL_STATE_LAYOUT.decode(accountInfo.data)
-            const updatedPoolData = {
-              ...selectedCardPool,
-              lpSupply: decodedAccount.lp_supply,
-              protocolFeesToken0: decodedAccount.protocol_fees_token_0,
-              protocolFeesToken1: decodedAccount.protocol_fees_token_1,
-              comulativeTradeFeesToken0: decodedAccount.cumulative_trade_fees_token_0,
-              comulativeTradeFeesToken1: decodedAccount.cumulative_trade_fees_token_1,
-              latestDynamicFeeRate: decodedAccount.latest_dynamic_fee_rate,
-              fundFeesToken0: decodedAccount.fund_fees_token_0,
-              fundFeesToken1: decodedAccount.fund_fees_token_1,
-              token0Vault: decodedAccount.token_0_vault,
-              token1Vault: decodedAccount.token_1_vault,
-              mint0Decimals: selectedCardPool?.mint0Decimals,
-              mint1Decimals: selectedCardPool?.mint1Decimals
-            }
-            setUpdatedPoolState(updatedPoolData)
+          const decodedAccount = POOL_STATE_LAYOUT.decode(accountInfo.data)
+          const updatedPoolData = {
+            ...selectedCardPool,
+            lpSupply: decodedAccount.lp_supply,
+            protocolFeesToken0: decodedAccount.protocol_fees_token_0,
+            protocolFeesToken1: decodedAccount.protocol_fees_token_1,
+            comulativeTradeFeesToken0: decodedAccount.cumulative_trade_fees_token_0,
+            comulativeTradeFeesToken1: decodedAccount.cumulative_trade_fees_token_1,
+            latestDynamicFeeRate: decodedAccount.latest_dynamic_fee_rate,
+            fundFeesToken0: decodedAccount.fund_fees_token_0,
+            fundFeesToken1: decodedAccount.fund_fees_token_1,
+            token0Vault: decodedAccount.token_0_vault,
+            token1Vault: decodedAccount.token_1_vault,
+            mint0Decimals: selectedCardPool?.mint0Decimals,
+            mint1Decimals: selectedCardPool?.mint1Decimals
+          }
+          setUpdatedPoolState(updatedPoolData)
         }
       } catch (e) {
         console.log('Error in getting the pool state account', e)
@@ -217,12 +217,12 @@ export const DepositWithdrawSlider: FC = () => {
       try {
         const configKey = await getAmmConfigId(0)
         const accountInfo = await connection.getAccountInfo(configKey)
-          const decodedAccount = AMM_CONFIG_LAYOUT.decode(accountInfo.data)
-          const updatedPoolData = {
-            ...selectedCardPool,
-            trade_fee_rate: decodedAccount.trade_fee_rate
-          }
-          setUpdatedPoolState(updatedPoolData)
+        const decodedAccount = AMM_CONFIG_LAYOUT.decode(accountInfo.data)
+        const updatedPoolData = {
+          ...selectedCardPool,
+          trade_fee_rate: decodedAccount.trade_fee_rate
+        }
+        setUpdatedPoolState(updatedPoolData)
       } catch (e) {
         console.log('Error in getting the config account info', e)
       }
@@ -523,7 +523,7 @@ export const DepositWithdrawSlider: FC = () => {
           withdrawBigStringFarm(withdrawableBalanceB?.div(new BN(2))?.toString(), selectedCardPool?.mint1Decimals)
         )
       }
-    setIsUserTyping(false)
+      setIsUserTyping(false)
     },
     [
       modeOfOperation,
@@ -547,7 +547,7 @@ export const DepositWithdrawSlider: FC = () => {
           if (Object.keys(selectedCardPool)?.length) {
             const { lpTokenAmount, otherTokenAmountInString } = await calculateOtherTokenAndLPAmount(
               selectedCard?.mintA?.symbol === 'SOL' ? await getMaxSolDepositAmount(userSourceTokenBal, connection) 
-              : userSourceTokenBal?.toString(),
+                : userSourceTokenBal?.toString(),
               0,
               Object.keys(updatedPoolState)?.length > 0 ? updatedPoolState : selectedCardPool,
               connection
@@ -561,7 +561,7 @@ export const DepositWithdrawSlider: FC = () => {
           if (Object.keys(selectedCardPool)?.length) {
             const { lpTokenAmount, otherTokenAmountInString } = await calculateOtherTokenAndLPAmount(
               selectedCard?.mintB?.symbol === 'SOL' ? await getMaxSolDepositAmount(userTargetTokenBal, connection)
-              : userTargetTokenBal?.toString(),
+                : userTargetTokenBal?.toString(),
               1,
               Object.keys(updatedPoolState)?.length > 0 ? updatedPoolState : selectedCardPool,
               connection
@@ -799,7 +799,6 @@ export const DepositWithdrawSlider: FC = () => {
             <DepositWithdrawAccordion
               withdrawableBalanceA={withdrawableBalanceA}
               withdrawableBalanceB={withdrawableBalanceB}
-              updatedPoolState={updatedPoolState}
             />
             <DepositWithdrawLabel text={'1. Enter Amounts'} />
             <TokenRow
@@ -837,7 +836,6 @@ export const DepositWithdrawSlider: FC = () => {
             <ReviewConfirm
               tokenAActionValue={isDeposit ? userSourceDepositAmount : userSourceWithdrawAmount}
               tokenBActionValue={isDeposit ? userTargetDepositAmount : userTargetWithdrawAmount}
-              updatedPoolState={updatedPoolState}
               isDeposit={isDeposit}
             />
             {/*{isDeposit && userPublicKey && (userSourceTokenBal === 0 || userTargetTokenBal === 0) && <SwapNow />}*/}

--- a/src/pages/FarmV4/FarmRow.tsx
+++ b/src/pages/FarmV4/FarmRow.tsx
@@ -104,7 +104,7 @@ const FarmRow: FC<{ pool: GAMMAPoolWithUserLiquidity }> = ({ pool, ...props }): 
                 border-grey-1 bg-grey-5 dark:bg-black-2 rounded-[2.5px] h-[30px] p-2"
           >
             {(
-              new BigNumber(pool?.['latestDynamicFeeRate'] || 0.0).div(10 ** 4).toNumber() ||
+              new BigNumber(pool?.latestDynamicFeeRate || 0.0).div(10 ** 4).toNumber() ||
               new BigNumber(pool?.config.tradeFeeRate || 0.0).div(10 ** 4).toNumber()
             ).toFixed(2)}
             %

--- a/src/pages/FarmV4/PoolStats.tsx
+++ b/src/pages/FarmV4/PoolStats.tsx
@@ -5,10 +5,7 @@ import { numberFormatter } from '@/utils'
 import BigNumber from 'bignumber.js'
 import { fetchTokensByPublicKey } from '@/api/gamma'
 
-export const PoolStats: FC<{ pool: GAMMAPool; updatedPoolState?: any }> = ({
-  pool,
-  updatedPoolState
-}): ReactElement => {
+export const PoolStats: FC<{ pool: GAMMAPool }> = ({ pool }): ReactElement => {
   const poolTVL = useMemo(() => {
     const liquidity = parseFloat(pool.tvl)
     return liquidity ? numberFormatter(liquidity) : '0.00'
@@ -24,37 +21,27 @@ export const PoolStats: FC<{ pool: GAMMAPool; updatedPoolState?: any }> = ({
 
   useEffect(() => {
     ;(async () => {
-      if (
-        !pool.mintA ||
-        !pool.mintB ||
-        !updatedPoolState?.comulativeTradeFeesToken0 ||
-        !updatedPoolState?.comulativeTradeFeesToken1
-      )
-        return
+      if (!pool.mintA || !pool.mintB) return
       setFees('Loading')
       const tokenListData = await fetchTokensByPublicKey(`${pool.mintA.address},${pool.mintB.address}`)
 
-      if (
-        !tokenListData.success ||
-        tokenListData.data.tokens?.length !== 2
-      )
-        return
+      if (!tokenListData.success || tokenListData.data.tokens?.length !== 2) return
 
       const tokenA = tokenListData.data.tokens[0]
       const tokenB = tokenListData.data.tokens[1]
 
-      const tokenAfee = new BigNumber(updatedPoolState.comulativeTradeFeesToken0)
-        .div(10**pool.mintA.decimals)
+      const tokenAfee = new BigNumber(pool.mintA.cumulativeTradeFees)
+        .div(10 ** pool.mintA.decimals)
         .multipliedBy(new BigNumber(tokenA.price))
-      const tokenBfee = new BigNumber(updatedPoolState.comulativeTradeFeesToken1)
-        .div(10**pool.mintB.decimals)
+      const tokenBfee = new BigNumber(pool.mintB.cumulativeTradeFees)
+        .div(10 ** pool.mintB.decimals)
         .multipliedBy(new BigNumber(tokenB.price))
 
       const totalFee = tokenAfee.plus(tokenBfee).toNumber()
 
       setFees(`$${numberFormatter(totalFee)}`)
     })()
-  }, [pool, updatedPoolState?.comulativeTradeFeesToken0, updatedPoolState?.comulativeTradeFeesToken1])
+  }, [pool])
 
   return (
     <>

--- a/src/pages/FarmV4/ReviewConfirm.tsx
+++ b/src/pages/FarmV4/ReviewConfirm.tsx
@@ -9,9 +9,8 @@ import BigNumber from 'bignumber.js'
 export const ReviewConfirm: FC<{
   tokenAActionValue: string
   tokenBActionValue: string
-  updatedPoolState: any
   isDeposit: boolean
-}> = ({ tokenAActionValue, tokenBActionValue, updatedPoolState, isDeposit }): ReactElement => {
+}> = ({ tokenAActionValue, tokenBActionValue, isDeposit }): ReactElement => {
   const { selectedCard } = useGamma()
   const { balance } = useWalletBalance()
 
@@ -42,7 +41,7 @@ export const ReviewConfirm: FC<{
           <Tooltip>
             <TooltipTrigger className={`!font-regular !font-semibold dark:text-text-darkmode-secondary
                         text-grey-1 underline decoration-dotted`}>
-            Pool Fee Rate
+              Pool Fee Rate
             </TooltipTrigger>
             <TooltipContent>
               This fee is dynamically calculated based on volatility in the pools to provide the best returns for LPs.
@@ -51,15 +50,18 @@ export const ReviewConfirm: FC<{
           </Tooltip>
 
           <span className="!font-regular font-semibold dark:text-grey-8 text-black-4">
-            {(new BigNumber(updatedPoolState?.latestDynamicFeeRate || 0.00).div(10**4).toNumber()
-              || new BigNumber(updatedPoolState?.trade_fee_rate || 0.00).div(10**4).toNumber()).toFixed(2)}%
+            {(
+              new BigNumber(selectedCard?.latestDynamicFeeRate || 0.0).div(10 ** 4).toNumber() ||
+              new BigNumber(selectedCard?.config.tradeFeeRate || 0.0).div(10 ** 4).toNumber()
+            ).toFixed(2)}
+            %
           </span>
         </div>
         <div className="flex justify-between mb-2">
           <Tooltip>
             <TooltipTrigger className={`!font-regular font-semibold 
                         dark:text-grey-2 text-grey-1 underline decoration-dotted`}>
-            Total {isDeposit ? 'Deposit' : 'Withdraw'}
+              Total {isDeposit ? 'Deposit' : 'Withdraw'}
             </TooltipTrigger>
             <TooltipContent>
               This is the sum of your deposits of Token A/B

--- a/src/types/gamma.ts
+++ b/src/types/gamma.ts
@@ -45,6 +45,7 @@ type GAMMAToken = {
   decimals: number
   tags: string[] // "hasFreeze" | "hasTransferFee" | "token-2022" | "community" | "unknown" ..etc
   extensions: ExtensionsItem
+  cumulativeTradeFees: number
 }
 
 type GAMMATokenList = {
@@ -99,6 +100,7 @@ interface GAMMAPool {
   pool_type: 'primary' | 'hyper'
   price?: string
   poolCreator: string
+  latestDynamicFeeRate: number
 }
 export type GAMMAPoolWithUserLiquidity = GAMMAPool & {
   userLpPosition: UserPortfolioLPPosition,
@@ -178,10 +180,10 @@ type GAMMAAPIBaseResponse<T> = {
 }
 
 type GAMMAPoolsResponse = GAMMAAPIBaseResponse<{
-  pools: GAMMAPool[]
+    pools: GAMMAPool[]
 } & GAMMAAPIPaginatedResponse>
 type GAMMAListTokenResponse = GAMMAAPIBaseResponse<{
-  tokens: TokenListToken[]
+    tokens: TokenListToken[]
 } & GAMMAAPIPaginatedResponse>
 type GAMMAStats = {
   tvl: string
@@ -215,5 +217,5 @@ export type {
   GAMMAListTokenResponse,
   GAMMAUser,
   GAMMAUserLPPositionWithPrice,
-   GAMMAStats
+  GAMMAStats
 }


### PR DESCRIPTION
### DEPENDS on https://github.com/GooseFX1/gfx-amm-api/pull/44

This pr adds, 

- latestDynamicFeeRate and cumulativeTradeFees in pool types
- refactor code to use the fee from api instead of updatePoolState
- Fixes loading issue in mobile and lite mode pool rows

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation
