### PR TITLE
prevent negative values in pool list/portfolio and drawer

### DIFF
--- a/src/pages/FarmV4/FarmRow.tsx
+++ b/src/pages/FarmV4/FarmRow.tsx
@@ -16,10 +16,9 @@ const FarmRow: FC<{ pool: GAMMAPoolWithUserLiquidity }> = ({ pool, ...props }): 
 
   const formattedTVL = useMemo(() => {
     const liquidity = parseFloat(pool.tvl)
-    return liquidity ? numberFormatter(liquidity) : '0.00'
+    return liquidity ? numberFormatter(Math.max(0, liquidity)) : '0.00'
   }, [pool])
-  const { formattedVolume, formattedFees, formattedAPR } = useMemo(
-    () => {
+  const { formattedVolume, formattedFees, formattedAPR } = useMemo(() => {
     if (!pool.stats) {
       return {
         formattedVolume: '0.00',
@@ -30,28 +29,30 @@ const FarmRow: FC<{ pool: GAMMAPoolWithUserLiquidity }> = ({ pool, ...props }): 
     switch (viewRange) {
       case 0:
         return {
-          formattedVolume: numberFormatter(pool.stats.daily.volumeTokenAUSD + pool.stats.daily.volumeTokenBUSD),
-          formattedFees: numberFormatter(pool.stats.daily.feesUSD),
-          formattedAPR: numberFormatter(pool.stats.daily.feesAprUSD)
+          formattedVolume: numberFormatter(
+            Math.max(0, pool.stats.daily.volumeTokenAUSD + pool.stats.daily.volumeTokenBUSD)
+          ),
+          formattedFees: numberFormatter(Math.max(0, pool.stats.daily.feesUSD)),
+          formattedAPR: numberFormatter(Math.max(0, pool.stats.daily.feesAprUSD))
         }
       case 1:
         return {
-          formattedVolume: numberFormatter(pool.stats.weekly.volumeTokenAUSD + pool.stats.weekly.volumeTokenBUSD),
-          formattedFees: numberFormatter(pool.stats.weekly.feesUSD),
-          formattedAPR: numberFormatter(pool.stats.weekly.feesAprUSD)
+          formattedVolume: numberFormatter(
+            Math.max(0, pool.stats.weekly.volumeTokenAUSD + pool.stats.weekly.volumeTokenBUSD)
+          ),
+          formattedFees: numberFormatter(Math.max(0, pool.stats.weekly.feesUSD)),
+          formattedAPR: numberFormatter(Math.max(0, pool.stats.weekly.feesAprUSD))
         }
       case 2:
         return {
           formattedVolume: numberFormatter(
-            pool.stats.monthly.volumeTokenAUSD + pool.stats.monthly.volumeTokenBUSD
+            Math.max(0, pool.stats.monthly.volumeTokenAUSD + pool.stats.monthly.volumeTokenBUSD)
           ),
-          formattedFees: numberFormatter(pool.stats.monthly.feesUSD),
-          formattedAPR: numberFormatter(pool.stats.monthly.feesAprUSD)
+          formattedFees: numberFormatter(Math.max(0, pool.stats.monthly.feesUSD)),
+          formattedAPR: numberFormatter(Math.max(0, pool.stats.monthly.feesAprUSD))
         }
     }
-    },
-    [pool.stats, viewRange]
-  )
+  }, [pool.stats, viewRange])
 
   return (
     <div

--- a/src/pages/FarmV4/MyPositions.tsx
+++ b/src/pages/FarmV4/MyPositions.tsx
@@ -135,7 +135,11 @@ const MyPositions: FC = () => {
                                   font-poppins text-tiny font-semibold dark:text-grey-8 text-black-4 mx-auto
                                   border-grey-1 bg-grey-5 dark:bg-black-2 rounded-[2.5px] h-[25px] px-1"
               >
-                {numberFormatter(pool.stats.monthly.tradeFeesUSD)}%
+                {(
+                  new BigNumber(pool?.latestDynamicFeeRate || 0.0).div(10 ** 4).toNumber() ||
+                  new BigNumber(pool?.config.tradeFeeRate || 0.0).div(10 ** 4).toNumber()
+                ).toFixed(2)}
+                %
               </div>
             )}
 
@@ -150,13 +154,13 @@ const MyPositions: FC = () => {
             )}
 
             {/* apr */}
-              <div className="flex items-center justify-center">
-                <Badge variant="default" size={'lg'} className={'to-brand-secondaryGradient-secondary/50'}>
-                  <span className={'font-poppins font-semibold my-0.5'}>
-                    {numberFormatter(pool.stats.daily.feesAprUSD)}%
-                  </span>
-                </Badge>
-              </div>
+            <div className="flex items-center justify-center">
+              <Badge variant="default" size={'lg'} className={'to-brand-secondaryGradient-secondary/50'}>
+                <span className={'font-poppins font-semibold my-0.5'}>
+                  {numberFormatter(Math.max(0, pool.stats.daily.feesAprUSD))}%
+                </span>
+              </Badge>
+            </div>
 
             {/* actions */}
             {(isTablet || isDesktop) && (

--- a/src/pages/FarmV4/PoolStats.tsx
+++ b/src/pages/FarmV4/PoolStats.tsx
@@ -8,16 +8,19 @@ import { fetchTokensByPublicKey } from '@/api/gamma'
 export const PoolStats: FC<{ pool: GAMMAPool }> = ({ pool }): ReactElement => {
   const poolTVL = useMemo(() => {
     const liquidity = parseFloat(pool.tvl)
-    return liquidity ? numberFormatter(liquidity) : '0.00'
+    return liquidity ? numberFormatter(Math.max(0, liquidity)) : '0.00'
   }, [pool])
   const dailyVolume = useMemo(
-    () => numberFormatter(pool?.stats?.daily?.volumeTokenAUSD + pool?.stats?.daily?.volumeTokenBUSD),
+    () => numberFormatter(Math.max(0, pool?.stats?.daily?.volumeTokenAUSD + pool?.stats?.daily?.volumeTokenBUSD)),
     [pool?.stats?.daily?.volumeTokenAUSD, pool?.stats?.daily?.volumeTokenBUSD]
   )
 
   const [fees, setFees] = useState<string>('Loading')
 
-  const dailyAPR = useMemo(() => numberFormatter(pool?.stats?.daily?.feesAprUSD), [pool?.stats?.daily?.feesAprUSD])
+  const dailyAPR = useMemo(
+    () => numberFormatter(Math.max(0, pool?.stats?.daily?.feesAprUSD)),
+    [pool?.stats?.daily?.feesAprUSD]
+  )
 
   useEffect(() => {
     ;(async () => {

--- a/src/pages/FarmV4/ReviewConfirm.tsx
+++ b/src/pages/FarmV4/ReviewConfirm.tsx
@@ -33,8 +33,11 @@ export const ReviewConfirm: FC<{
             Est. 24H Fees
           </span>
           <span className="!font-regular font-semibold dark:text-grey-8 text-black-4">
-            ${numberFormatter(selectedCard?.stats?.daily?.feesUSD || 0.00,
-            new BigNumber(selectedCard?.stats?.daily?.feesUSD || 0.00).gt(0) ? 4 : 2)}
+            $
+            {numberFormatter(
+              Math.max(0, selectedCard?.stats?.daily?.feesUSD) || 0.0,
+              new BigNumber(Math.max(0, selectedCard?.stats?.daily?.feesUSD) || 0.0).gt(0) ? 4 : 2
+            )}
           </span>
         </div>
         <div className="flex justify-between mb-2">


### PR DESCRIPTION
This PR adds logic to prevent negative values in pool list, portfolio and deposit withdraw slider. 

Note: We need to revert this check for APR when the issue is fixed in the backend as APR can actually be negative.

## How has this been tested?

## Types of changes

- [ ] Technical Debt (non-breaking change which removes unused code/assets)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] The related ClickUp task has been linked to this PR
- [ ] The person creating the pull request is listed in "Assignees"
- [ ] Change requires updated documentation
